### PR TITLE
Solve java issue with OpenRefine 3.4 beta 2

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -42,7 +42,8 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 - Launch OpenRefine
 - Click the openrefine.exe (this will launch a command prompt window, but you can ignore that and wait for the browser to launch)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
--If you get a Java error when you try to open it you can download[Windows kit with embedded Java] (https://openrefine.org/download.html) of the OpenRefine 3.4 beta 2 release.
+-If you get a Java error when you try to open it you can try downloading [OpenRefine 3.4 Beta release for Windows with embedded Java] (https://openrefine.org/download.html).
+
 
 #### Mac
 

--- a/setup.md
+++ b/setup.md
@@ -42,7 +42,7 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 - Launch OpenRefine
 - Click the openrefine.exe (this will launch a command prompt window, but you can ignore that and wait for the browser to launch)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
--If you get a Java error when you try to open it you can try downloading [OpenRefine 3.4 Beta release for Windows with embedded Java] (https://openrefine.org/download.html).
+- If you get a Java error when you try to open it you can try downloading [OpenRefine 3.4 Beta release for Windows with embedded Java] (https://openrefine.org/download.html).
 
 
 #### Mac

--- a/setup.md
+++ b/setup.md
@@ -38,10 +38,11 @@ default browser. OpenRefine runs in your default browser. It will not run correc
 - Download software from [http://openrefine.org](http://openrefine.org)
 - Unzip the downloaded file into a directory by right-clicking and 
 selecting “Extract…”. Name that directory something like OpenRefine.
-- Go to your newly created OpenRefine directory.
+- Go to your newly created OpenRefine directory. 
 - Launch OpenRefine
 - Click the openrefine.exe (this will launch a command prompt window, but you can ignore that and wait for the browser to launch)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
+-If you get a java error when you try to open it you can download[Windows kit with embedded Java] (https://github.com/OpenRefine/OpenRefine/releases/download/3.4-beta2/openrefine-win-with-java-3.4-beta2.zip) of the OpenRefine 3.4 beta 2 release.
 
 #### Mac
 

--- a/setup.md
+++ b/setup.md
@@ -38,7 +38,7 @@ default browser. OpenRefine runs in your default browser. It will not run correc
 - Download software from [http://openrefine.org](http://openrefine.org)
 - Unzip the downloaded file into a directory by right-clicking and 
 selecting “Extract…”. Name that directory something like OpenRefine.
-- Go to your newly created OpenRefine directory. 
+- Go to your newly created OpenRefine directory.
 - Launch OpenRefine
 - Click the openrefine.exe (this will launch a command prompt window, but you can ignore that and wait for the browser to launch)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.

--- a/setup.md
+++ b/setup.md
@@ -42,7 +42,7 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 - Launch OpenRefine
 - Click the openrefine.exe (this will launch a command prompt window, but you can ignore that and wait for the browser to launch)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
--If you get a java error when you try to open it you can download[Windows kit with embedded Java] (https://github.com/OpenRefine/OpenRefine/releases/download/3.4-beta2/openrefine-win-with-java-3.4-beta2.zip) of the OpenRefine 3.4 beta 2 release.
+-If you get a Java error when you try to open it you can download[Windows kit with embedded Java] (https://openrefine.org/download.html) of the OpenRefine 3.4 beta 2 release.
 
 #### Mac
 

--- a/setup.md
+++ b/setup.md
@@ -42,7 +42,7 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 - Launch OpenRefine
 - Click the openrefine.exe (this will launch a command prompt window, but you can ignore that and wait for the browser to launch)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
-- If you get a Java error when you try to open it you can try downloading [OpenRefine 3.4 Beta release for Windows with embedded Java] (https://openrefine.org/download.html).
+- If you get a Java error when you try to open it you can try downloading [OpenRefine 3.4 beta 2 Windows kit with embedded Java](https://openrefine.org/download.html).
 
 
 #### Mac


### PR DESCRIPTION
Add the information about the Windows kit with embedded Java of the OpenRefine 3.4 beta 2 release

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
