### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -14,6 +14,8 @@ keypoints:
 - "OpenRefine will automatically track any steps allowing you to backtrack as needed and providing a record of all work done"
 ---
 
+{% include base_path.html %}
+
 # Lesson
 
 ## Motivations for the OpenRefine Lesson
@@ -38,7 +40,7 @@ keypoints:
 
 Note: this is a Java program that runs on your machine (not in the cloud). It runs inside your browser, but no web connection is needed.
 
-Follow the [Setup]({{ site.baseurl }}/setup.html) instructions to install OpenRefine.
+Follow the [Setup]({{relative_root_path}}/setup.html) instructions to install OpenRefine.
 
 If after installation and running OpenRefine, it does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
 

--- a/_episodes/02-working-with-openrefine.md
+++ b/_episodes/02-working-with-openrefine.md
@@ -21,6 +21,8 @@ keypoints:
 - "OpenRefine can transform the values of a column."
 ---
 
+{% include base_path.html %}
+
 # Lesson
 
 ## Creating a new OpenRefine project
@@ -32,15 +34,15 @@ OpenRefine can import a variety of file types, including tab separated (`tsv`), 
 In this first step, we'll browse our computer to the sample data file for this lesson.
 In this case, we will be using data obtained from interviews of farmers in two countries in eastern sub-Saharan Africa (Mozambique and Tanzania).
 Instructions on downloading the data are available
-[here]({{site.baseurl}}/setup.html).
+[here]({{relative_root_path}}/setup.html).
 
 Once OpenRefine is launched in your browser, the left margin has options to `Create Project`, `Open Project`, or `Import Project`. Here we will create a new project:
 
 1. Click `Create Project` and select `Get data from` `This Computer`.
-2. Click `Choose Files` and select the file `SAFI_openrefine.csv` that you downloaded in the [setup step]({{site.baseurl}}/setup.html). Click `Open` or double-click on the filename.
+2. Click `Choose Files` and select the file `SAFI_openrefine.csv` that you downloaded in the [setup step]({{relative_root_path}}/setup.html). Click `Open` or double-click on the filename.
 3. Click `Next>>` under the browse button to upload the data into OpenRefine.
 4. OpenRefine gives you a preview - a chance to show you it understood the file. If, for example, your file was really tab-delimited, the preview might look strange. You would then choose the correct separator in the box shown and click `Update Preview` (middle right). If this is the wrong file, click `<<Start Over` (upper left).  There are also options to indicate whether the dataset has column headers included and whether OpenRefine should skip a number of rows before reading the data.
-![Parse Options](../fig/OR_01_parse_options.png)
+![Parse Options]({{relative_root_path}}/fig/OR_01_parse_options.png)
 
 5. If all looks well, click `Create Project>>` (upper right).
 
@@ -127,7 +129,7 @@ In OpenRefine, clustering means "finding groups of different values that might b
 3. Select the `key collision` method and `metaphone3` keying function. It should identify two clusters.
 4. Click the `Merge?` box beside each cluster, then click `Merge Selected and Recluster` to apply the corrections to the dataset.
 4. Try selecting different `Methods` and `Keying Functions` again, to see what new merges are suggested.
-5. You should find that using the default settings, no more clusters are found, for example to merge `Ruaca-Nhamuenda` with `Ruaca` or `Chirdozo` with `Chirodzo`. (Note that the `nearest neighbor` method with `ppm` distance, `radius` &ge; 4, and `block chars` &le; 4 will find these clusters, as well as other settings with `levenshtein` distance) 
+5. You should find that using the default settings, no more clusters are found, for example to merge `Ruaca-Nhamuenda` with `Ruaca` or `Chirdozo` with `Chirodzo`. (Note that the `nearest neighbor` method with `ppm` distance, `radius` &ge; 4, and `block chars` &le; 4 will find these clusters, as well as other settings with `levenshtein` distance)
 6. To merge these values we will hover over them in the village text facet, select edit, and manually change the names. Change `Chirdozo` to `Chirodzo` and `Ruaca-Nhamuenda` to `Ruaca`. You should now have four clusters: `Chirodzo`, `God`, `Ruaca` and `49`.
 
 Important: If you `Merge` using a different method or keying function, or more times than described in the instructions above,
@@ -145,7 +147,7 @@ The data in the `items_owned` column is a set of items in a list. The list is in
 
 1. Click the down arrow at the top of the `items_owned` column. Choose `Edit Cells` > `Transform...`
 2. This will open up a window into which you can type a GREL expression. GREL stands for General Refine Expression Language.
-![OR_Transform](../fig/OR_02_Transform.png)
+![OR_Transform]({{relative_root_path}}/fig/OR_02_Transform.png)
 
 3. First we will remove all of the left square brackets (`[`). In the Expression box type `value.replace("[", "")` and click `OK`.
 
@@ -221,7 +223,7 @@ It's common while exploring and cleaning a dataset to discover after you've made
 
 ## Trim Leading and Trailing Whitespace
 
-Words with spaces at the beginning or end are particularly hard for we humans to tell from strings without, but the blank characters will make a difference to the computer. We usually want to remove these. As of version 3.4 of OpenRefine, the option to trim leading and trailing whitespaces is present at the moment of importing the data (see image at the top of this page). 
+Words with spaces at the beginning or end are particularly hard for we humans to tell from strings without, but the blank characters will make a difference to the computer. We usually want to remove these. As of version 3.4 of OpenRefine, the option to trim leading and trailing whitespaces is present at the moment of importing the data (see image at the top of this page).
 
 If you unchecked that box when importing data, or if leading or trailing whitespaces were introduced while splitting columns, or other operations, OpenRefine also provides a tool to remove blank characters from the beginning and end of any entries that have them.
 

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,8 +1,8 @@
 ---
-layout: page
-title: "Instructor Notes"
-permalink: /guide/
+title: Instructor Notes
 ---
+
+{% include base_path.html %}
 
 ## Lesson
 
@@ -11,48 +11,48 @@ This time allotted for the teaching and exercises in lessons one through eight i
 ## Setup
 
 - There is a separate file for the setup instructions for installing OpenRefine
-([setup](../setup.html)).
+([setup]({{relative_root_path}}/setup.html)).
 - If Internet Explorer is the default browser for participants, OpenRefine may have trouble opening. The URL can be copied and pasted into a Google Chrome or Firefox browser. Or, participants can be encouraged in advance of the workshop to set one of these two browsers as their default.
 
 ## The datasets used
 
 - The dataset used in this lesson can be downloaded from Figshare through
- the link on the ([setup page](../setup.html)).
+ the link on the ([setup page]({{relative_root_path}}/setup.html)).
 - It will need to be downloaded to the local machine before it can be loaded into OpenRefine.
 - A general description of the dataset used in the Social Sciences lessons can be found [in the workshop data home page](http://www.datacarpentry.org/socialsci-workshop/data/)
 
 ## The Lessons
 
-[Introduction](../01-introduction/)
+[Introduction]({{relative_root_path}}/01-introduction/index.html)
 
 - Explains what OpenRefine is, what it is used for and where to get help.
 
-[Working with OpenRefine](../02-working-with-openrefine/)
+[Working with OpenRefine]({{relative_root_path}}/02-working-with-openrefine/index.html)
 
 - Covers the creation of an OpenRefine project using our dataset.
 - The file has a single header row and is csv.
 - Facets and clustering are introduced and there is a discussion on the different clustering algorithms and how they may produce different results.
 - Splitting columns is covered as is undo/redo.
 
-[Filtering and Sorting](../03-filter-sort/)
+[Filtering and Sorting]({{relative_root_path}}/03-filter-sort/index.html)
 
 - Using Include and Exclude from a facet is covered and the difference between faceting and filtering is explained.
 - The various sort options for single or multiple columns is covered.
 
-[Examining Numbers in OpenRefine](../04-numbers/)
+[Examining Numbers in OpenRefine]({{relative_root_path}}/04-numbers/index.html)
 
 - Explains that everything is a string until you change it.
 - Explains how to change the data type and the additional faceting ability it provides.
 
-[Using scripts](../05-scripts/)
+[Using scripts]({{relative_root_path}}/05-scripts/index.html)
 
 - Explains how actions within a project can be copied to an external file and re-applied. The same file is used to re-apply the changes.
 
-[Saving results](../06-saving/)
+[Saving results]({{relative_root_path}}/06-saving/index.html)
 
 - Covers the overall format of a project 'file' and how the components can be viewed.
 - This may require installing additional software on Windows machine (e.g. 7-zip) as the built-in un-zipping facility does not work with tar.gz files.
 
-[Other resources in OpenRefine](../07-resources/)
+[Other resources in OpenRefine]({{relative_root_path}}/07-resources/index.html)
 
 - Just a list of various OpenRefine resources available on-line (taken from the Ecology lessons)

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: .
+permalink: index.html
 ---
 
 A part of the data workflow is preparing the data for analysis. Some of this
@@ -21,25 +22,24 @@ edits by hand.
 > ## Getting Started
 >
 > Data Carpentry's teaching is hands-on, so participants are encouraged to use
-> their own computers to ensure the proper setup of tools for an efficient 
+> their own computers to ensure the proper setup of tools for an efficient
 > workflow.
 >
 > **These lessons assume no prior knowledge of the skills or tools.**
 >
-> To get started, follow the directions in the "[Setup](setup.html)" tab to 
+> To get started, follow the directions in the "[Setup](setup.html)" tab to
 > download data to your computer and follow any installation instructions.
 >
 > #### Prerequisites
 >
-> This lesson requires a working copy of OpenRefine (also called 
+> This lesson requires a working copy of OpenRefine (also called
 > GoogleRefine).
-> 
-> To most effectively use these materials, please make sure to install 
+>
+> To most effectively use these materials, please make sure to install
 > everything *before* working through this lesson.
 {: .prereq}
 
 > ## For Instructors
-> If you are teaching this lesson in a workshop, please see the 
-> [Instructor notes](guide/).
+> If you are teaching this lesson in a workshop, please see the
+> [Instructor notes](guide/index.html).
 {: .prereq}
-

--- a/setup.md
+++ b/setup.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Setup
 ---
 
@@ -13,11 +12,11 @@ title: Setup
 > household features (e.g. construction materials used, number of household
 > members), agricultural practices (e.g. water usage), and assets (e.g. number
 > and types of livestock).
-> 
+>
 > The data used in this lesson
 > is a subset of the teaching version that has been intentionally 'messed up'
 > for this lesson.
-> 
+>
 > **Download** the data file to your computer by [clicking this link](https://ndownloader.figshare.com/files/11502815). (direct link: <https://ndownloader.figshare.com/files/11502815>)
 {: .prereq}
 
@@ -33,10 +32,10 @@ title: Setup
 
 #### Windows
 
-- Check that you have Firefox or Chrome browsers installed and set as your 
+- Check that you have Firefox or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
 - Download software from [http://openrefine.org](http://openrefine.org)
-- Unzip the downloaded file into a directory by right-clicking and 
+- Unzip the downloaded file into a directory by right-clicking and
 selecting “Extract…”. Name that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
@@ -47,25 +46,24 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 
 #### Mac
 
-- Check that you have Firefox or Chrome browsers installed and set as your 
+- Check that you have Firefox or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
 - Download software from [http://openrefine.org](http://openrefine.org)
-- Unzip the downloaded file into a directory by double-clicking it. Name 
+- Unzip the downloaded file into a directory by double-clicking it. Name
 that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
-- Drag icon into Applications folder, and Ctrl-click/Open… it. 
+- Drag icon into Applications folder, and Ctrl-click/Open… it.
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
 
 #### Linux
 
-- Check that you have Firefox or Chrome browsers installed and set as your 
+- Check that you have Firefox or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
 - Download software from [http://openrefine.org](http://openrefine.org)
-- Unzip the downloaded file into a directory. Name 
+- Unzip the downloaded file into a directory. Name
 that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
 - Type ./refine into the terminal within the OpenRefine directory
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
-


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Data Carpentry Lessons page](https://datacarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://datacarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.