### PR TITLE
Update 02-working-with-openrefine.md

### DIFF
--- a/_episodes/02-working-with-openrefine.md
+++ b/_episodes/02-working-with-openrefine.md
@@ -226,7 +226,7 @@ Words with spaces at the beginning or end are particularly hard for we humans to
 If you unchecked that box when importing data, or if leading or trailing whitespaces were introduced while splitting columns, or other operations, OpenRefine also provides a tool to remove blank characters from the beginning and end of any entries that have them.
 
 1. Edit the `village` on the first row to introduce a space at the end, set to `God `.
-2. Create a new text facet for the `village` column `respondent_wall_type`. You should now see two different entries for `God`, one of those has a trailing whitespace.
+2. Create a new text facet for the `village` column. You should now see two different entries for `God`, one of those has a trailing whitespace.
 3. To remove the whitespace, choose `Edit cells` > `Common transforms` > `Trim leading and trailing whitespace`.
 4. You should now see only four choices in your text facet again.
 


### PR DESCRIPTION
line  229 remove  'respodent_wall_type'
The reference to the column respondent_wall_type must misplaced/an error and learners will find the reference confusing.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
