### PR TITLE
update OpenRefine wiki links to new User Manual

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -45,6 +45,6 @@ If after installation and running OpenRefine, it does not automatically open for
 
 ## Getting help for OpenRefine.
 
-You can find out a lot more about OpenRefine at [http://openrefine.org](http://openrefine.org) and check out some great introductory videos. These videos and other on OpenRefine can also be found on YouTube, search under 'OpenRefine' There is a [Google Group](https://groups.google.com/forum/?hl=en#!forum/openrefine) that can answer a lot of beginner questions and problems. Information can also be found on [StackOverflow](https://stackoverflow.com/questions/tagged/openrefine) where you can find a lot of help. As with other programs of this type, OpenRefine libraries are available too, where you can find a script you need and copy it into your OpenRefine instance to run it on your dataset.
+You can find out a lot more about OpenRefine at [https://openrefine.org](https://openrefine.org) and check out some great introductory videos. These videos and other on OpenRefine can also be found on YouTube, search under 'OpenRefine' There is a [Google Group](https://groups.google.com/g/openrefine) that can answer a lot of beginner questions and problems. Information can also be found on [StackOverflow](https://stackoverflow.com/questions/tagged/openrefine) where you can find a lot of help. As with other programs of this type, OpenRefine libraries are available too, where you can find a script you need and copy it into your OpenRefine instance to run it on your dataset.
 
 {% include links.md %}

--- a/_episodes/02-working-with-openrefine.md
+++ b/_episodes/02-working-with-openrefine.md
@@ -27,7 +27,7 @@ keypoints:
 
 In Windows, you can start the OpenRefine program by double-clicking on the openrefine.exe file. Java services will start automatically on your machine, and OpenRefine will open in your browser. On a Mac, OpenRefine can be launched from your Applications folder. If you are using Linux, you will need to navigate to your OpenRefine directory in the command line and run `./refine`.
 
-OpenRefine can import a variety of file types, including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, and Google Spreadsheets. See the [OpenRefine Importers page](https://github.com/OpenRefine/OpenRefine/wiki/Importers) for more information.
+OpenRefine can import a variety of file types, including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, and Google Spreadsheets. See the [OpenRefine Create a Project by Importing Data page](https://docs.openrefine.org/manual/starting/#create-a-project-by-importing-data) for more information.
 
 In this first step, we'll browse our computer to the sample data file for this lesson.
 In this case, we will be using data obtained from interviews of farmers in two countries in eastern sub-Saharan Africa (Mozambique and Tanzania).
@@ -98,7 +98,7 @@ along with a number representing how many times that value occurs in the column.
 {: .challenge}
 
 > ## More on Facets
-> [OpenRefine Wiki: Faceting](https://github.com/OpenRefine/OpenRefine/wiki/Faceting)
+> [OpenRefine Manual: Facets](https://docs.openrefine.org/manual/facets)
 >
 > As well as 'Text facets' Refine also supports a range of other types of facet. These include:
 >

--- a/_episodes/07-resources.md
+++ b/_episodes/07-resources.md
@@ -19,9 +19,8 @@ OpenRefine is more than a simple data cleaning tool. People are using it for all
 
 OpenRefine has its own web site with documentation and a book:
 
-* [OpenRefine web site](http://openrefine.org/)
-* [OpenRefine Documentation for Users](https://github.com/OpenRefine/OpenRefine/wiki/Documentation-For-Users)
-* [OpenRefine documentation Wiki site](https://github.com/OpenRefine/OpenRefine/wiki/Documentation-For-Users)
+* [OpenRefine web site](https://openrefine.org/)
+* [OpenRefine User Manual](https://docs.openrefine.org/) (the previous [OpenRefine Wiki](https://github.com/OpenRefine/OpenRefine/wiki) is being phased out)
 * [Using OpenRefine](http://www.worldcat.org/title/using-openrefine-the-essential-openrefine-guide-that-takes-you-from-data-analysis-and-error-fixing-to-linking-your-dataset-to-the-web/oclc/889271264) book by Ruben Verborgh, Max De Wilde and Aniket Sawant
 * [OpenRefine history from Wikipedia](https://en.wikipedia.org/wiki/OpenRefine)
 

--- a/setup.md
+++ b/setup.md
@@ -35,7 +35,7 @@ title: Setup
 
 - Check that you have Firefox or Chrome browsers installed and set as your 
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
-- Download software from [http://openrefine.org](http://openrefine.org)
+- Download software from [https://openrefine.org](https://openrefine.org)
 - Unzip the downloaded file into a directory by right-clicking and 
 selecting “Extract…”. Name that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
@@ -49,7 +49,7 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 
 - Check that you have Firefox or Chrome browsers installed and set as your 
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
-- Download software from [http://openrefine.org](http://openrefine.org)
+- Download software from [https://openrefine.org](https://openrefine.org)
 - Unzip the downloaded file into a directory by double-clicking it. Name 
 that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
@@ -61,7 +61,7 @@ that directory something like OpenRefine.
 
 - Check that you have Firefox or Chrome browsers installed and set as your 
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
-- Download software from [http://openrefine.org](http://openrefine.org)
+- Download software from [https://openrefine.org](https://openrefine.org)
 - Unzip the downloaded file into a directory. Name 
 that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.


### PR DESCRIPTION
This PR updates links to OpenRefine reference from the old Wiki to the new docs "User Manual" site, https://docs.openrefine.org/
Refine is phasing out the wiki, so the User Manual should be the preferred reference. It slightly changes wording in link text to reflect the update.