### PR TITLE
Add Edge and Opera as supported browsers

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -31,7 +31,7 @@ title: Setup
 >
 {: .prereq}
 
-#### Windows
+### Windows
 
 - Check that you have Firefox, Edge, Opera or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
@@ -45,7 +45,7 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 - If you get a Java error when you try to open it you can try downloading [OpenRefine 3.4 beta 2 Windows kit with embedded Java](https://openrefine.org/download.html).
 
 
-#### Mac
+### Mac
 
 - Check that you have Firefox, Edge, Opera or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
@@ -58,7 +58,7 @@ that directory something like OpenRefine.
 For Troubleshooting help, see [the apple support page](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
 
-#### Linux
+### Linux
 
 - Check that you have Firefox or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser.

--- a/setup.md
+++ b/setup.md
@@ -13,11 +13,11 @@ title: Setup
 > household features (e.g. construction materials used, number of household
 > members), agricultural practices (e.g. water usage), and assets (e.g. number
 > and types of livestock).
-> 
+>
 > The data used in this lesson
 > is a subset of the teaching version that has been intentionally 'messed up'
 > for this lesson.
-> 
+>
 > **Download** the data file to your computer by [clicking this link](https://ndownloader.figshare.com/files/11502815). (direct link: <https://ndownloader.figshare.com/files/11502815>)
 {: .prereq}
 
@@ -33,10 +33,10 @@ title: Setup
 
 #### Windows
 
-- Check that you have Firefox or Chrome browsers installed and set as your 
+- Check that you have Firefox, Edge, Opera or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
 - Download software from [https://openrefine.org](https://openrefine.org)
-- Unzip the downloaded file into a directory by right-clicking and 
+- Unzip the downloaded file into a directory by right-clicking and
 selecting “Extract…”. Name that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
@@ -47,23 +47,23 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 
 #### Mac
 
-- Check that you have Firefox or Chrome browsers installed and set as your 
+- Check that you have Firefox, Edge, Opera or Chrome browsers installed and set as your
 default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
 - Download software from [https://openrefine.org](https://openrefine.org)
-- Unzip the downloaded file into a directory by double-clicking it. Name 
+- Unzip the downloaded file into a directory by double-clicking it. Name
 that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
-- Drag icon into Applications folder, and Control-click the app icon, then choose Open from the shortcut menu. 
+- Drag icon into Applications folder, and Control-click the app icon, then choose Open from the shortcut menu.
 For Troubleshooting help, see [the apple support page](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)
 - If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
 
 #### Linux
 
-- Check that you have Firefox or Chrome browsers installed and set as your 
-default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
+- Check that you have Firefox or Chrome browsers installed and set as your
+default browser. OpenRefine runs in your default browser.
 - Download software from [https://openrefine.org](https://openrefine.org)
-- Unzip the downloaded file into a directory. Name 
+- Unzip the downloaded file into a directory. Name
 that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine


### PR DESCRIPTION
This closes #31 by adding Edge and Opera to the setup instructions for Windows and MacOS. We may need to update this PR if #98 is merged first, since both PRs update the same file.

I don't think Internet Explorer is commonly found on Linux, so I removed the noticed from the Linux section. 