### PR TITLE
fix: remove lesson heading from episodes

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -14,8 +14,6 @@ keypoints:
 - "OpenRefine will automatically track any steps allowing you to backtrack as needed and providing a record of all work done."
 ---
 
-# Lesson
-
 ## Motivations for the OpenRefine Lesson
 
 * Data is often very messy. OpenRefine provides a set of tools to allow you to identify and amend the messy data.

--- a/_episodes/02-working-with-openrefine.md
+++ b/_episodes/02-working-with-openrefine.md
@@ -21,8 +21,6 @@ keypoints:
 - "OpenRefine can transform the values of a column."
 ---
 
-# Lesson
-
 ## Creating a new OpenRefine project
 
 In Windows, you can start the OpenRefine program by double-clicking on the openrefine.exe file. Java services will start automatically on your machine, and OpenRefine will open in your browser. On a Mac, OpenRefine can be launched from your Applications folder. If you are using Linux, you will need to navigate to your OpenRefine directory in the command line and run `./refine`.

--- a/_episodes/03-filter-sort.md
+++ b/_episodes/03-filter-sort.md
@@ -13,8 +13,6 @@ keypoints:
 - "OpenRefine provides a way to sort and filter data without affecting the raw data."
 ---
 
-# Lesson
-
 ## Filtering
 
 There are many entries in our data table. We can filter it to work on a subset of the data in the list for the next set of operations. Please ensure you perform this step to save time during the class.

--- a/_episodes/04-numbers.md
+++ b/_episodes/04-numbers.md
@@ -12,8 +12,6 @@ keypoints:
 - "OpenRefine also provides ways to to examine and clean numerical data."
 ---
 
-# Lesson
-
 ## Numbers
 
 When a table is imported into OpenRefine, all columns are treated as containing text values. We saw earlier how we can sort column values as numbers, but this does not change the cells in a column from text to numbers. Rather, this interprets the values as numbers for the purposes of sorting but keeps the underlying data type as is. We can, however, transform columns from text to other data types (e.g. number or date) using the `Edit cells` > `Common transforms` feature. Here we will experiment changing columns to numbers and see what additional capabilities that grants us.

--- a/_episodes/05-scripts.md
+++ b/_episodes/05-scripts.md
@@ -13,8 +13,6 @@ keypoints:
 - "All changes are being tracked in OpenRefine, and this information can be used for scripts for future analyses or reproducing an analysis."
 ---
 
-# Lesson
-
 ## How OpenRefine records what you have done
 
 As you conduct your data cleaning and preliminary analysis, OpenRefine saves every change you make to the dataset. These

--- a/_episodes/06-saving.md
+++ b/_episodes/06-saving.md
@@ -12,8 +12,6 @@ keypoints:
 - "Projects can be shared with collaborators, enabling them to see, reproduce and check all data cleaning steps you performed."
 ---
 
-# Lesson
-
 ## Saving and Exporting a Project
 
 In OpenRefine you can save or export the project. This means you're saving the data and all the 

--- a/_episodes/07-resources.md
+++ b/_episodes/07-resources.md
@@ -11,8 +11,6 @@ keypoints:
 - "Other examples and resources online are good for learning more about OpenRefine."
 ---
 
-# Lesson
-
 ## Using online resources to get help with OpenRefine
 
 OpenRefine is more than a simple data cleaning tool. People are using it for all sorts of activities. Here are some other resources that might prove useful.


### PR DESCRIPTION
<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
instructor.training@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>

Removed h1 Lesson from all episodes.
