### PR TITLE
Remove markdown linting warnings - see #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/) 
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--socsci--openref-E01563.svg)](https://swcarpentry.slack.com/messages/C9Y0UEXPY) 
+[![Create a Slack Account with us](
+    https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](
+        https://swc-slack-invite.herokuapp.com/)
+[![Slack Status](
+    https://img.shields.io/badge/Slack_Channel-dc--socsci--openref-E01563.svg)](
+        https://swcarpentry.slack.com/messages/C9Y0UEXPY)
 [![DOI](https://zenodo.org/badge/92422790.svg)](https://zenodo.org/badge/latestdoi/92422790)
 
 # openrefine-socialsci

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -59,10 +59,10 @@ or [http://localhost:3333](http://localhost:3333) to launch the program.
 You can find out a lot more about OpenRefine at [http://openrefine.org](http://openrefine.org)
 and check out some great introductory videos.
 
-These videos and others on OpenRefine can also be found on YouTube by searching
-under 'OpenRefine'.  There is a [Google Group](https://groups.google.com/g/openrefine)
-that can answer a lot of beginner questions and problems. Information can also
-be found on [StackOverflow](https://stackoverflow.com/questions/tagged/openrefine) where
+These videos and others on OpenRefine can also be found on YouTube by searching under
+'OpenRefine'.  There is a [Google Group](https://groups.google.com/g/openrefine) that
+can answer a lot of beginner questions and problems. Information can also be found on
+[StackOverflow](https://stackoverflow.com/questions/tagged/openrefine) where
 you can find a lot of help. As with other programs of this type, OpenRefine
 libraries are available too, where you can find a script you need and copy it
 into your OpenRefine instance to run it on your dataset.

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -16,12 +16,20 @@ keypoints:
 
 ## Motivations for the OpenRefine Lesson
 
-* Data is often very messy. OpenRefine provides a set of tools to allow you to identify and amend the messy data.
-* It is important to know what you did to your data. Additionally, journals, granting agencies, and other institutions are requiring documentation of the steps you took when working with your data. With OpenRefine, you can capture all actions applied to your raw data and share them with your publication as supplemental material.
+* Data is often very messy. OpenRefine provides a set of tools to allow you to
+  identify and amend the messy data.
+* It is important to know what you did to your data. Additionally, journals,
+  granting agencies, and other institutions are requiring documentation of the
+  steps you took when working with your data. With OpenRefine, you can capture
+  all actions applied to your raw data and share them with your publication as
+  supplemental material.
 * All actions are easily reversed in OpenRefine.
-* If you save your work it will be to a new file. OpenRefine always uses a copy of your data and _does not_ modify your original dataset.
-* Data cleaning steps often need repeating with multiple files. OpenRefine keeps track of all of your actions and allows them to be applied to different datasets.
-* Some concepts such as clustering algorithms are quite complex, but OpenRefine makes it easy to introduce them, use them, and show their power.
+* If you save your work it will be to a new file. OpenRefine always uses a copy
+  of your data and _does not_ modify your original dataset.
+* Data cleaning steps often need repeating with multiple files. OpenRefine
+  keeps track of all of your actions and allows them to be applied to different datasets.
+* Some concepts such as clustering algorithms are quite complex, but OpenRefine
+  makes it easy to introduce them, use them, and show their power.
 
 ## Features
 
@@ -30,25 +38,33 @@ keypoints:
   Help section below.
 * Works with large-ish datasets (100,000 rows). Can adjust memory allocation to
   accommodate larger datasets.
-* OpenRefine always keeps your data private on your own computer until you choose to share it. It works by running a small server on your computer and using your web browser to interact with it, but your private data never leaves your computer unless you want it to.
+* OpenRefine always keeps your data private on your own computer until you
+  choose to share it. It works by running a small server on your computer and
+  using your web browser to interact with it, but your private data never
+  leaves your computer unless you want it to.
 
 ## Before we get started
 
-Note: this is a Java program that runs on your machine (not in the cloud). It runs inside your browser, but no web connection is needed.
+Note: this is a Java program that runs on your machine (not in the cloud). It
+runs inside your browser, but no web connection is needed.
 
 Follow the [Setup]({{ page.root }}{% link setup.md %}) instructions to install OpenRefine.
 
-If after installation and running OpenRefine, it does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
-
+If after installation and running OpenRefine, it does not automatically open
+for you, point your browser at [http://127.0.0.1:3333/](http://127.0.0.1:3333/)
+or [http://localhost:3333](http://localhost:3333) to launch the program.
 
 ## Getting help for OpenRefine
 
+You can find out a lot more about OpenRefine at [http://openrefine.org](http://openrefine.org)
+and check out some great introductory videos.
 
-You can find out a lot more about OpenRefine at [http://openrefine.org](http://openrefine.org) and check out some great introductory videos.
-These videos and others on OpenRefine can also be found on YouTube by searching under 'OpenRefine'.  There is a [Google Group](https://groups.google.com/g/openrefine)
-that can answer a lot of beginner questions and problems. Information can also be found on [StackOverflow](https://stackoverflow.com/questions/tagged/openrefine)
-where you can find a lot of help. As with other programs of this type, OpenRefine libraries are available too, where you can find a script you need and copy it
+These videos and others on OpenRefine can also be found on YouTube by searching
+under 'OpenRefine'.  There is a [Google Group](https://groups.google.com/g/openrefine)
+that can answer a lot of beginner questions and problems. Information can also
+be found on [StackOverflow](https://stackoverflow.com/questions/tagged/openrefine) where
+you can find a lot of help. As with other programs of this type, OpenRefine
+libraries are available too, where you can find a script you need and copy it
 into your OpenRefine instance to run it on your dataset.
-
 
 {% include links.md %}

--- a/_episodes/02-working-with-openrefine.md
+++ b/_episodes/02-working-with-openrefine.md
@@ -23,73 +23,121 @@ keypoints:
 
 ## Creating a new OpenRefine project
 
-In Windows, you can start the OpenRefine program by double-clicking on the openrefine.exe file. Java services will start automatically on your machine, and OpenRefine will open in your browser. On a Mac, OpenRefine can be launched from your Applications folder. If you are using Linux, you will need to navigate to your OpenRefine directory in the command line and run `./refine`.
+In Windows, you can start the OpenRefine program by double-clicking on the
+openrefine.exe file. Java services will start automatically on your machine,
+and OpenRefine will open in your browser. On a Mac, OpenRefine can be launched
+from your Applications folder. If you are using Linux, you will need to
+navigate to your OpenRefine directory in the command line and run `./refine`.
 
-OpenRefine can import a variety of file types, including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, and Google Spreadsheets. See the [OpenRefine Create a Project by Importing Data page](https://docs.openrefine.org/manual/starting/#create-a-project-by-importing-data) for more information.
+OpenRefine can import a variety of file types, including tab separated (`tsv`),
+comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, and
+Google Spreadsheets. See the [OpenRefine Create a Project by Importing Data
+page](https://docs.openrefine.org/manual/starting/#create-a-project-by-importing-data)
+for more information.
 
-In this first step, we'll browse our computer to the sample data file for this lesson.
-In this case, we will be using data obtained from interviews of farmers in two countries in eastern sub-Saharan Africa (Mozambique and Tanzania).
+In this first step, we'll browse our computer to the sample data file for this
+lesson.
+In this case, we will be using data obtained from interviews of farmers in two
+countries in eastern sub-Saharan Africa (Mozambique and Tanzania).
 Instructions on downloading the data are available
 [here]({{ page.root }}{% link setup.md %}).
 
-Once OpenRefine is launched in your browser, the left margin has options to `Create Project`, `Open Project`, or `Import Project`. Here we will create a new project:
+Once OpenRefine is launched in your browser, the left margin has options to
+`Create Project`, `Open Project`, or `Import Project`. Here we will create a
+new project:
 
 1. Click `Create Project` and select `Get data from` `This Computer`.
-2. Click `Choose Files` and select the file `SAFI_openrefine.csv` that you downloaded in the [setup step]({{ page.root }}{% link setup.md %}). Click `Open` or double-click on the filename.
+2. Click `Choose Files` and select the file `SAFI_openrefine.csv` that you
+   downloaded in the [setup step]({{ page.root }}{% link setup.md %}). Click
+   `Open` or double-click on the filename.
 3. Click `Next>>` under the browse button to upload the data into OpenRefine.
-4. OpenRefine gives you a preview - a chance to show you it understood the file. If, for example, your file was really tab-delimited, the preview might look strange. You would then choose the correct separator in the box shown and click `Update Preview` (middle right). If this is the wrong file, click `<<Start Over` (upper left).  There are also options to indicate whether the dataset has column headers included and whether OpenRefine should skip a number of rows before reading the data.
+4. OpenRefine gives you a preview - a chance to show you it understood the
+   file. If, for example, your file was really tab-delimited, the preview might
+   look strange. You would then choose the correct separator in the box shown
+   and click `Update Preview` (middle right). If this is the wrong file, click
+   `<<Start Over` (upper left).  There are also options to indicate whether the
+   dataset has column headers included and whether OpenRefine should skip a
+   number of rows before reading the data.
 ![Parse Options](../fig/OR_01_parse_options.png)
 
 5. If all looks well, click `Create Project>>` (upper right).
 
-Note that at step 1, you could upload data in a standard form from a web address by selecting `Get data from` `Web Addresses (URLs)`. However, this won't work for all URLs.
+Note that at step 1, you could upload data in a standard form from a web
+address by selecting `Get data from` `Web Addresses (URLs)`. However, this
+won't work for all URLs.
 
 ## Using Facets
 
 *Exploring data by applying multiple filters*
 
-Facets are one of the most useful features of OpenRefine and can help both get an overview of the data in a project as well as help you bring more consistency to the data. OpenRefine supports faceted browsing as a mechanism for
+Facets are one of the most useful features of OpenRefine and can help both get
+an overview of the data in a project as well as help you bring more consistency
+to the data. OpenRefine supports faceted browsing as a mechanism for
 
 * seeing a big picture of your data, and
 * filtering down to just the subset of rows that you want to change in bulk.
 
-A 'Facet' groups all the like values that appear in a column, and then allows you to filter the data by these values and edit values across many records at the same time.
+A 'Facet' groups all the like values that appear in a column, and then allows
+you to filter the data by these values and edit values across many records at
+the same time.
 
-One type of Facet is called a 'Text facet'. This groups all the identical text values in a column and lists each value with the number of records it appears in. The facet information always appears in the left hand panel in the OpenRefine interface.
+One type of Facet is called a 'Text facet'. This groups all the identical text
+values in a column and lists each value with the number of records it appears
+in. The facet information always appears in the left hand panel in the
+OpenRefine interface.
 
 Here we will use faceting to look for potential errors in data entry in the `village` column.
 
 1. Scroll over to the `village` column.
 2. Click the down arrow and choose `Facet` > `Text facet`.
-3. In the left panel, you'll now see a box containing every unique value in the `village` column
-along with a number representing how many times that value occurs in the column.
-4. Try sorting this facet by name and by count. Do you notice any problems with the data? What are they?
-5. Hover the mouse over one of the names in the `Facet` list. You should see that you have an `edit` function available.
-6. You could use this to fix an error immediately, and OpenRefine will ask whether you want to make the same correction to every value it finds like that one. But OpenRefine offers even better ways to find and fix these errors, which we'll use instead. We'll learn about these when we talk about clustering.
+3. In the left panel, you'll now see a box containing every unique value in the
+   `village` column along with a number representing how many times that value
+   occurs in the column.
+4. Try sorting this facet by name and by count. Do you notice any problems with
+   the data? What are they?
+5. Hover the mouse over one of the names in the `Facet` list. You should see
+   that you have an `edit` function available.
+6. You could use this to fix an error immediately, and OpenRefine will ask
+   whether you want to make the same correction to every value it finds like
+   that one. But OpenRefine offers even better ways to find and fix these
+   errors, which we'll use instead. We'll learn about these when we talk about
+   clustering.
 
 > ## Solution
 > - `Chirdozo` is likely a mis-entry of `Chirodzo`.
 > - `Ruca` is likely a mis-entry of `Ruaca`.
-> - `Ruaca - Nhamuenda` and `Ruaca-Nhamuenda` refer to the same place (differ only by spaces around the hyphen). You might also wonder if both of these are the same as `Ruaca`. We will see how to correct these misspelled and mistyped entries in a later exercise.
-> - The entry `49` is almost certainly an error but you will not be able to fix it by reference to other data.
+> - `Ruaca - Nhamuenda` and `Ruaca-Nhamuenda` refer to the same place (differ
+>   only by spaces around the hyphen). You might also wonder if both of these
+>   are the same as `Ruaca`. We will see how to correct these misspelled and
+>   mistyped entries in a later exercise.
+> - The entry `49` is almost certainly an error but you will not be able to fix
+>   it by reference to other data.
 {: .solution}
 
 > ## Exercise
 >
-> 1. Using faceting, find out how many different `interview_date` values there are in the survey results.
+> 1. Using faceting, find out how many different `interview_date` values there
+>    are in the survey results.
 >
 > 2. Is the column formatted as Text or Date?
 >
-> 3. Use faceting to produce a timeline display for `interview_date`. You will need to use `Edit cells` > `Common transforms` > `To date` to convert this column to dates.
+> 3. Use faceting to produce a timeline display for `interview_date`. You will
+>    need to use `Edit cells` > `Common transforms` > `To date` to convert this
+>    column to dates.
 >
 > 4. During what period were most of the interviews collected?
 >
 > > ## Solution
 > >
-> > For the column `interview_date` do `Facet` > `Text facet`. A box will appear in the left panel showing that there are 19 unique entries in
+> > For the column `interview_date` do `Facet` > `Text facet`. A box will
+> > appear in the left panel showing that there are 19 unique entries in
 > > this column.
-> > By default, the column `interview_date` is formatted as Text. You can change the format by doing `Edit cells` > `Common transforms` >
-> > `To date`.  Notice the the values in the column turn green. Doing `Facet` > `Timeline facet` creates a box in the left panel that shows a histogram of the number of entries for each date.
+> > By default, the column `interview_date` is formatted as Text. You can
+> > change the format by doing `Edit cells` > `Common transforms` > `To date`.
+> >
+> > Notice the the values in the column turn green. Doing `Facet` > `Timeline
+> > facet` creates a box in the left panel that shows a histogram of the number
+> > of entries for each date.
 > >
 > > Most of the data was collected in November of 2016.
 > {: .solution}
@@ -98,58 +146,100 @@ along with a number representing how many times that value occurs in the column.
 > ## More on Facets
 > [OpenRefine Manual: Facets](https://docs.openrefine.org/manual/facets)
 >
-> As well as 'Text facets' Refine also supports a range of other types of facet. These include:
+> As well as 'Text facets' Refine also supports a range of other types of
+> facet. These include:
 >
 > * Numeric facets
 > * Timeline facets (for dates)
 > * Custom facets
 > * Scatterplot facets
 >
-> **Numeric and Scatterplot facets** display graphs instead of lists of values. The numeric facet graph includes 'drag and drop' controls you can use to set a start and end range to filter the data displayed. These facets are explored further in [Examining Numbers in OpenRefine](http://www.datacarpentry.org/OpenRefine-ecology-lesson/03-numbers/)
+> **Numeric and Scatterplot facets** display graphs instead of lists of values.
+> The numeric facet graph includes 'drag and drop' controls you can use to set
+> a start and end range to filter the data displayed. These facets are explored
+> further in [Examining Numbers in
+> OpenRefine](http://www.datacarpentry.org/OpenRefine-ecology-lesson/03-numbers/)
 >
-> **Custom facets** are a range of different types of facets. Some of the default custom facets are:
+> **Custom facets** are a range of different types of facets. Some of the
+> default custom facets are:
 >
-> * Word facet - this breaks down text into words and counts the number of records each word appears in
-> * Duplicates facet - this results in a binary facet of 'true' or 'false'. Rows appear in the 'true' facet if the value in the selected column is an exact match for a value in the same column in another row
-> * Text length facet - creates a numeric facet based on the length (number of characters) of the text in each row for the selected column. This can be useful for spotting incorrect or unusual data in a field where specific lengths are expected (e.g. if the values are expected to be years, any row with a text length more than 4 for that column is likely to be incorrect)
-> * Facet by blank - a binary facet of 'true' or 'false'. Rows appear in the 'true' facet if they have no data present in that column. This is useful when looking for rows missing key data.
+> * Word facet - this breaks down text into words and counts the number of
+>   records each word appears in
+> * Duplicates facet - this results in a binary facet of 'true' or 'false'.
+>   Rows appear in the 'true' facet if the value in the selected column is an
+>   exact match for a value in the same column in another row
+> * Text length facet - creates a numeric facet based on the length (number of
+>   characters) of the text in each row for the selected column. This can be
+>   useful for spotting incorrect or unusual data in a field where specific
+>   lengths are expected (e.g. if the values are expected to be years, any row
+>   with a text length more than 4 for that column is likely to be incorrect)
+> * Facet by blank - a binary facet of 'true' or 'false'. Rows appear in the
+>   'true' facet if they have no data present in that column. This is useful
+>   when looking for rows missing key data.
 {: .callout}
 
 ## Using clustering to detect possible typing errors
 
-In OpenRefine, clustering means "finding groups of different values that might be alternative representations of the same thing". For example, the two strings `New York` and `new york` are very likely to refer to the same concept and just have capitalization differences. Likewise, `Gödel` and `Godel` probably refer to the same person. Clustering is a very powerful tool for cleaning datasets which contain misspelled or mistyped entries. OpenRefine has several clustering algorithms built in. Experiment with them, and learn more about these algorithms and how they work.
+In OpenRefine, clustering means "finding groups of different values that might
+be alternative representations of the same thing". For example, the two strings
+`New York` and `new york` are very likely to refer to the same concept and just
+have capitalization differences. Likewise, `Gödel` and `Godel` probably refer
+to the same person. Clustering is a very powerful tool for cleaning datasets
+which contain misspelled or mistyped entries. OpenRefine has several clustering
+algorithms built in. Experiment with them, and learn more about these
+algorithms and how they work.
 
 1. In the `village` Text Facet we created in the step above, click the `Cluster` button.
-2. In the resulting pop-up window, you can change the `Method` and the `Keying Function`. Try different combinations to
- see what different mergers of values are suggested.
-3. Select the `key collision` method and `metaphone3` keying function. It should identify two clusters.
-4. Click the `Merge?` box beside each cluster, then click `Merge Selected and Recluster` to apply the corrections to the dataset.
-4. Try selecting different `Methods` and `Keying Functions` again, to see what new merges are suggested.
-5. You should find that using the default settings, no more clusters are found, for example to merge `Ruaca-Nhamuenda` with `Ruaca` or `Chirdozo` with `Chirodzo`. (Note that the `nearest neighbor` method with `ppm` distance, `radius` &ge; 4, and `block chars` &le; 4 will find these clusters, as well as other settings with `levenshtein` distance)
-6. To merge these values we will hover over them in the village text facet, select edit, and manually change the names. Change `Chirdozo` to `Chirodzo` and `Ruaca-Nhamuenda` to `Ruaca`. You should now have four clusters: `Chirodzo`, `God`, `Ruaca` and `49`.
+2. In the resulting pop-up window, you can change the `Method` and the `Keying
+   Function`. Try different combinations to see what different mergers of values are suggested.
+3. Select the `key collision` method and `metaphone3` keying function. It
+   should identify two clusters.
+4. Click the `Merge?` box beside each cluster, then click `Merge Selected and
+   Recluster` to apply the corrections to the dataset.
+4. Try selecting different `Methods` and `Keying Functions` again, to see what
+   new merges are suggested.
+5. You should find that using the default settings, no more clusters are found,
+   for example to merge `Ruaca-Nhamuenda` with `Ruaca` or `Chirdozo` with
+   `Chirodzo`. (Note that the `nearest neighbor` method with `ppm` distance,
+   `radius` &ge; 4, and `block chars` &le; 4 will find these clusters, as well
+   as other settings with `levenshtein` distance)
+6. To merge these values we will hover over them in the village text facet,
+   select edit, and manually change the names. Change `Chirdozo` to `Chirodzo`
+   and `Ruaca-Nhamuenda` to `Ruaca`. You should now have four clusters:
+   `Chirodzo`, `God`, `Ruaca` and `49`.
 
-Important: If you `Merge` using a different method or keying function, or more times than described in the instructions above,
-your solutions for later exercises will not be the same as shown in those exercise solutions.
+Important: If you `Merge` using a different method or keying function, or more
+times than described in the instructions above, your solutions for later
+exercises will not be the same as shown in those exercise solutions.
 
 ## Different clustering algorithms
 
-The technical details of how the different clustering algorithms work can be found at the link below.
+The technical details of how the different clustering algorithms work can be
+found at the link below.
 
 [More on clustering](https://github.com/OpenRefine/OpenRefine/wiki/Clustering-In-Depth)
 
 ## Transforming data
 
-The data in the `items_owned` column is a set of items in a list. The list is in square brackets and each item is in single quotes. Before we split the list into individual items in the next section, we first want to remove the brackets and the quotes.
+The data in the `items_owned` column is a set of items in a list. The list is
+in square brackets and each item is in single quotes. Before we split the list
+into individual items in the next section, we first want to remove the brackets
+and the quotes.
 
-1. Click the down arrow at the top of the `items_owned` column. Choose `Edit Cells` > `Transform...`
-2. This will open up a window into which you can type a GREL expression. GREL stands for General Refine Expression Language.
+1. Click the down arrow at the top of the `items_owned` column. Choose
+   `Edit Cells` > `Transform...`
+2. This will open up a window into which you can type a GREL expression. GREL
+   stands for General Refine Expression Language.
 ![OR_Transform](../fig/OR_02_Transform.png)
 
-3. First we will remove all of the left square brackets (`[`). In the Expression box type `value.replace("[", "")` and click `OK`.
+3. First we will remove all of the left square brackets (`[`). In the
+   Expression box type `value.replace("[", "")` and click `OK`.
 
-4. What the expression means is this: Take the `value` in each cell in the selected column and replace all of the "[" with "" (i.e. nothing - delete).
+4. What the expression means is this: Take the `value` in each cell in the
+   selected column and replace all of the "[" with "" (i.e. nothing - delete).
 
-5. Click `OK`. You should see in the `items_owned` column that there are no longer any left square brackets.
+5. Click `OK`. You should see in the `items_owned` column that there are no
+   longer any left square brackets.
 
 > ## Exercise
 >
@@ -164,10 +254,12 @@ The data in the `items_owned` column is a set of items in a list. The list is in
 > {: .solution}
 {: .challenge}
 
-Now that we have cleaned out extraneous characters from our `items_owned` column, we can use a text facet to see which items
-were commonly owned or rarely owned by the interview respondents.
+Now that we have cleaned out extraneous characters from our `items_owned`
+column, we can use a text facet to see which items were commonly owned or
+rarely owned by the interview respondents.
 
-1. Click the down arrow at the top of the `items_owned` column. Choose `Facet` > `Custom text facet...`
+1. Click the down arrow at the top of the `items_owned` column. Choose
+   `Facet` > `Custom text facet...`
 2. In the `Expression` box, type `value.split(";")`.
 3. Click `OK`.
 
@@ -198,7 +290,8 @@ You should now see a new text facet box in the left-hand pane.
 {: .challenge}
 
 > ## Exercise
-> Perform the same clean up steps for the `months_no_water`, `liv_owned`, `res_change`, and `no_food_mitigation` columns.
+> Perform the same clean up steps for the `months_no_water`, `liv_owned`,
+> `res_change`, and `no_food_mitigation` columns.
 > Hint: To reuse a GREL command, click the `History` tab and then
 > click `Reuse` next to the command you would like to apply to that
 > column.
@@ -206,26 +299,43 @@ You should now see a new text facet box in the left-hand pane.
 
 ## Using undo and redo
 
-It's common while exploring and cleaning a dataset to discover after you've made a change that you really should have done something else first. OpenRefine provides `Undo` and `Redo` operations to make this easy.
+It's common while exploring and cleaning a dataset to discover after you've
+made a change that you really should have done something else first. OpenRefine
+provides `Undo` and `Redo` operations to make this easy.
 
 > ## Exercise
 >
-> 1. Click where it says `Undo / Redo` on the left side of the screen. All the changes you have made so far are listed here.
-> 2. Click on the step that you want to go back to, in this case go back several steps to before you had done any text transformation.
-> 3. Visually confirm that those columns now contain the special characters that we had removed previously.
-> 3. Notice that you can still click on the later steps to `Redo` the actions. Before moving on to the next lesson, redo all the steps in your analysis so that all of the columns you modified are lacking in square brackets, spaces, and single quotes.
+> 1. Click where it says `Undo / Redo` on the left side of the screen. All the
+>    changes you have made so far are listed here.
+> 2. Click on the step that you want to go back to, in this case go back
+>    several steps to before you had done any text transformation.
+> 3. Visually confirm that those columns now contain the special characters
+>    that we had removed previously.
+> 3. Notice that you can still click on the later steps to `Redo` the actions.
+>    Before moving on to the next lesson, redo all the steps in your analysis
+>    so that all of the columns you modified are lacking in square brackets,
+>    spaces, and single quotes.
 {: .challenge}
 
 
 ## Trim Leading and Trailing Whitespace
 
-Words with spaces at the beginning or end are particularly hard for we humans to tell from strings without, but the blank characters will make a difference to the computer. We usually want to remove these. As of version 3.4 of OpenRefine, the option to trim leading and trailing whitespaces is present at the moment of importing the data (see image at the top of this page).
+Words with spaces at the beginning or end are particularly hard for we humans
+to tell from strings without, but the blank characters will make a difference
+to the computer. We usually want to remove these. As of version 3.4 of
+OpenRefine, the option to trim leading and trailing whitespaces is present at
+the moment of importing the data (see image at the top of this page).
 
-If you unchecked that box when importing data, or if leading or trailing whitespaces were introduced while splitting columns, or other operations, OpenRefine also provides a tool to remove blank characters from the beginning and end of any entries that have them.
+If you unchecked that box when importing data, or if leading or trailing
+whitespaces were introduced while splitting columns, or other operations,
+OpenRefine also provides a tool to remove blank characters from the beginning
+and end of any entries that have them.
 
 1. Edit the `village` on the first row to introduce a space at the end, set to `God `.
-2. Create a new text facet for the `village` column. You should now see two different entries for `God`, one of those has a trailing whitespace.
-3. To remove the whitespace, choose `Edit cells` > `Common transforms` > `Trim leading and trailing whitespace`.
+2. Create a new text facet for the `village` column. You should now see two
+   different entries for `God`, one of those has a trailing whitespace.
+3. To remove the whitespace, choose `Edit cells` > `Common transforms` >
+   `Trim leading and trailing whitespace`.
 4. You should now see only four choices in your text facet again.
 
 {% include links.md %}

--- a/_episodes/03-filter-sort.md
+++ b/_episodes/03-filter-sort.md
@@ -15,11 +15,16 @@ keypoints:
 
 ## Filtering
 
-There are many entries in our data table. We can filter it to work on a subset of the data in the list for the next set of operations. Please ensure you perform this step to save time during the class.
+There are many entries in our data table. We can filter it to work on a subset
+of the data in the list for the next set of operations. Please ensure you
+perform this step to save time during the class.
 
-1. Click the down arrow next to `respondent_roof_type` > `Text filter`. A `respondent_roof_type` facet will appear on the left margin.
-2. Type in `mabat` and press return. There are 58 matching rows of the original 131 rows (and these rows are selected for the subsequent steps).
-3. At the top, change the view to `Show` 50 `rows`. This way you will see most of the matching rows.
+1. Click the down arrow next to `respondent_roof_type` > `Text filter`. A
+   `respondent_roof_type` facet will appear on the left margin.
+2. Type in `mabat` and press return. There are 58 matching rows of the original
+   131 rows (and these rows are selected for the subsequent steps).
+3. At the top, change the view to `Show` 50 `rows`. This way you will see most
+   of the matching rows.
 
 > ## Exercise
 >
@@ -27,9 +32,11 @@ There are many entries in our data table. We can filter it to work on a subset o
 > 2. How would you restrict this to only one of the roof types?
 >
 > > ## Solution
-> > 1. Do `Facet` > `Text facet` on the `respondent_roof_type` column after filtering. This will show that
-> > two names match your filter criteria. They are `mabatipitched` and `mabatisloping`.
-> > 2. To restrict to only one of these two roof types, you could include more letters in your filter.
+> > 1. Do `Facet` > `Text facet` on the `respondent_roof_type` column after
+> >    filtering. This will show that two names match your filter criteria.
+> >    They are `mabatipitched` and `mabatisloping`.
+> > 2. To restrict to only one of these two roof types, you could include more
+> >    letters in your filter.
 > >
 > {: .solution}
 {: .challenge}
@@ -37,12 +44,19 @@ There are many entries in our data table. We can filter it to work on a subset o
 ### Excluding entries
 
 
-In addition to the simple text filtering we used above, another way to narrow our filter is to `include` and/or `exclude` entries in a facet. You will see the `include` or `exclude` options if you hover over the name in the facet window.
+In addition to the simple text filtering we used above, another way to narrow
+our filter is to `include` and/or `exclude` entries in a facet. You will see
+the `include` or `exclude` options if you hover over the name in the facet
+window.
 
-If you still have your facet for `respondent_roof_type`, you can use it, or use drop-down menu > `Facet` > `Text facet` to create a new facet. Only the entries with names that agree with your `Text filter` will be included in this facet.
+If you still have your facet for `respondent_roof_type`, you can use it, or use
+drop-down menu > `Facet` > `Text facet` to create a new facet. Only the entries
+with names that agree with your `Text filter` will be included in this facet.
 
-Faceting and filtering look very similar. A good distinction is that faceting gives you an overview description of all of the data that
-is currently selected, while filtering allows you to select a subset of your data for analysis.
+Faceting and filtering look very similar. A good distinction is that faceting
+gives you an overview description of all of the data that is currently
+selected, while filtering allows you to select a subset of your data for
+analysis.
 
 
 > ## Exercise
@@ -51,12 +65,14 @@ is currently selected, while filtering allows you to select a subset of your dat
 >
 > > ## Solution
 > >
-> > 1. In the facet (left margin), click on one of the names, such as `mabatisloping`. Notice that when you click on the name, or hover
-> > over it, there are entries to the right for `edit` and `include`.
-> > 2. Click `include`. This will explicitly include this roof type, and exclude others that are not explicitly included. Notice that the
-> option now changes to `exclude`.
-> > 3. Click `include` and `exclude` on the other roof type and notice how the two entries appear and disappear
-> >  from the table.
+> > 1. In the facet (left margin), click on one of the names, such as
+> >    `mabatisloping`. Notice that when you click on the name, or hover over
+> >    it, there are entries to the right for `edit` and `include`.
+> > 2. Click `include`. This will explicitly include this roof type, and
+> >    exclude others that are not explicitly included. Notice that the option
+> >    now changes to `exclude`.
+> > 3. Click `include` and `exclude` on the other roof type and notice how the
+> >    two entries appear and disappear from the table.
 > >
 > {: .solution}
 {: .challenge}
@@ -66,21 +82,34 @@ Remove the filter before moving on so that you again have the full dataset of 13
 ## Sort
 
 You can sort the data by a column by using the drop-down menu in that column.
-There you can sort by `text`, `numbers`, `dates` or `booleans` (`TRUE` or `FALSE` values). You can also specify what order to put `Blanks` and `Errors` in the sorted results.
+There you can sort by `text`, `numbers`, `dates` or `booleans` (`TRUE` or
+`FALSE` values). You can also specify what order to put `Blanks` and `Errors`
+in the sorted results.
 
-If this is your first time sorting this table, then the drop-down menu for the selected column shows `Sort...`. Select what you would like to sort by (such as `numbers`). Additional options will then appear for you to fine-tune your sorting.
+If this is your first time sorting this table, then the drop-down menu for the
+selected column shows `Sort...`. Select what you would like to sort by (such as
+`numbers`). Additional options will then appear for you to fine-tune your
+sorting.
 
 > ## Exercise
 >
-> Sort the data by `gps_Altitude`. Do you think the first few entries may have incorrect altitudes?
+> Sort the data by `gps_Altitude`. Do you think the first few entries may have
+> incorrect altitudes?
 >
 > > ## Solution
-> > In the `gps_Altitude` column, select `Sort...` > `numbers` and select `smallest first`. The first few values are all 0. The altitudes are more likely 'missing' than incorrect. The survey is delivered by Smartphone with the gps information added automatically by the app. The lack of an altitude value suggests that the smartphone was unable to provide it and it defaulted to 0.
+> > In the `gps_Altitude` column, select `Sort...` > `numbers` and select
+> > `smallest first`. The first few values are all 0. The altitudes are more
+> > likely 'missing' than incorrect. The survey is delivered by Smartphone with
+> > the gps information added automatically by the app. The lack of an altitude
+> > value suggests that the smartphone was unable to provide it and it
+> > defaulted to 0.
 > {: .solution}
 {: .challenge}
 
 
-If you try to re-sort a column that you have already used, the drop-down menu changes slightly, to > `Sort` without the `...`, to remind you that you have already used this column. It will give you additional options:
+If you try to re-sort a column that you have already used, the drop-down menu
+changes slightly, to > `Sort` without the `...`, to remind you that you have
+already used this column. It will give you additional options:
 
 * `Sort` > `Sort...` - This option enables you to modify your original sort.
 * `Sort` > `Reverse` - This option allows you to reverse the order of the sort.
@@ -88,25 +117,43 @@ If you try to re-sort a column that you have already used, the drop-down menu ch
 
 ### Sorting by multiple columns
 
-You can sort by multiple columns by performing sort on additional columns. The sort will depend on the order in which you select columns to sort. To restart the sorting process with a particular column, check the `sort by this column alone` box in the `Sort` pop-up menu.
+You can sort by multiple columns by performing sort on additional columns. The
+sort will depend on the order in which you select columns to sort. To restart
+the sorting process with a particular column, check the `sort by this column
+alone` box in the `Sort` pop-up menu.
 
-If you go back to one of the already sorted columns and select > `Sort` > `Remove sort`, that column is removed from your multiple sort. If it is the only column sorted, then data reverts to its original order.
+If you go back to one of the already sorted columns and select > `Sort` >
+`Remove sort`, that column is removed from your multiple sort. If it is the
+only column sorted, then data reverts to its original order.
 
 > ## Exercise
 >
-> We discovered in an earlier lesson that the value for one of the `village` entries was given as 49. This is clearly wrong. By looking at the GPS coordinates for the entries of the other villages can we decide what village the data in that column was collected from?
+> We discovered in an earlier lesson that the value for one of the `village`
+> entries was given as 49. This is clearly wrong. By looking at the GPS
+> coordinates for the entries of the other villages can we decide what village
+> the data in that column was collected from?
 > 1. Sort on `gps_Latitude` as a number with the smallest first.
 > 2. Add a sort on `gps_Longitude` as a number with the smallest first.
-> 3. Using the drop down arrow on the `village` column, select `Edit column` > `Move column to end`. This will allow you to compare village names with GPS coordinates.
-> 4. Scroll through the entries until you find village `49`. Can you tell from it's GPS coordinates which village it belong to?
-> 5. Now sort only by `interview_date` as date. Move the `village` column to the start of the table. Does the row where village is `49` group with one particular village? Is it the same village as when comparing GPS coordinates?
+> 3. Using the drop down arrow on the `village` column, select `Edit column` >
+>    `Move column to end`. This will allow you to compare village names with GPS coordinates.
+> 4. Scroll through the entries until you find village `49`. Can you tell from
+>    it's GPS coordinates which village it belong to?
+> 5. Now sort only by `interview_date` as date. Move the `village` column to
+>    the start of the table. Does the row where village is `49` group with one
+>    particular village? Is it the same village as when comparing GPS
+>    coordinates?
 >
 > > ## Solution
 > >
-> > The interview data for that row is in a small cluster of Chirodzo interviews when sorting by GPS coordinates. When sorting by interview date, it is also with Chirodzo interviews. In fact, only Chirodzo had interviews conducted on that date.
+> > The interview data for that row is in a small cluster of Chirodzo
+> > interviews when sorting by GPS coordinates. When sorting by interview date,
+> > it is also with Chirodzo interviews. In fact, only Chirodzo had interviews
+> > conducted on that date.
 > {: .solution}
 {: .challenge}
 
-Perform a text facet on the `village` column and change `49` to the village name that was determined in the previous exercise. You should now have only three village names.
+Perform a text facet on the `village` column and change `49` to the village
+name that was determined in the previous exercise. You should now have only
+three village names.
 
 {% include links.md %}

--- a/_episodes/04-numbers.md
+++ b/_episodes/04-numbers.md
@@ -14,35 +14,62 @@ keypoints:
 
 ## Numbers
 
-When a table is imported into OpenRefine, all columns are treated as containing text values. We saw earlier how we can sort column values as numbers, but this does not change the cells in a column from text to numbers. Rather, this interprets the values as numbers for the purposes of sorting but keeps the underlying data type as is. We can, however, transform columns from text to other data types (e.g. number or date) using the `Edit cells` > `Common transforms` feature. Here we will experiment changing columns to numbers and see what additional capabilities that grants us.
+When a table is imported into OpenRefine, all columns are treated as containing
+text values. We saw earlier how we can sort column values as numbers, but this
+does not change the cells in a column from text to numbers. Rather, this
+interprets the values as numbers for the purposes of sorting but keeps the
+underlying data type as is. We can, however, transform columns from text to
+other data types (e.g. number or date) using the `Edit cells` > `Common
+transforms` feature. Here we will experiment changing columns to numbers and
+see what additional capabilities that grants us.
 
-Be sure to remove any `Text filter` facets you have enabled from the left panel so that we can examine our whole dataset. You can remove an existing facet by clicking the `x` in the upper left of that facet window.
+Be sure to remove any `Text filter` facets you have enabled from the left panel
+so that we can examine our whole dataset. You can remove an existing facet by
+clicking the `x` in the upper left of that facet window.
 
-To transform cells in the `years_farm` column to numbers, click the down arrow for that column, then `Edit cells` > `Common transforms…` > `To number`. You will notice the `years_farm` values change from left-justified to right-justified, and black to green in color.
+To transform cells in the `years_farm` column to numbers, click the down arrow
+for that column, then `Edit cells` > `Common transforms…` > `To number`. You
+will notice the `years_farm` values change from left-justified to
+right-justified, and black to green in color.
 
 > ## Exercise
 >
-> Transform three more columns, `no_membrs`, `years_liv`, and `buildings_in_compound`, from text to numbers. Can all columns be transformed to numbers? - Try it with `village` for example.
+> Transform three more columns, `no_membrs`, `years_liv`, and
+> `buildings_in_compound`, from text to numbers. Can all columns be transformed
+> to numbers? - Try it with `village` for example.
 >
 > > ## Solution
 > >
-> > Only observations that include only numerals (0-9) can be transformed to numbers. If you apply a number transformation to
-> > a column that doesn't meet this criteria, and then click the `Undo / Redo` tab, you will see a step that starts with
-> > `Text transform on 0 cells`. This means that the data in that column was not transformed.
+> > Only observations that include only numerals (0-9) can be transformed to
+> > numbers. If you apply a number transformation to a column that doesn't meet
+> > this criteria, and then click the `Undo / Redo` tab, you will see a step
+> > that starts with `Text transform on 0 cells`. This means that the data in
+> > that column was not transformed.
 > {: .solution}
 {: .challenge}
 
 ### Numeric facet
-Sometimes non-numeric values or blanks occur in a column where numbers are expected. Such values may represent errors in data entry, and we want to find them.
-We can do that with a `Numeric facet`.
+Sometimes non-numeric values or blanks occur in a column where numbers are
+expected. Such values may represent errors in data entry, and we want to find
+them. We can do that with a `Numeric facet`.
 
 > ## Exercise
-> 1. For a column you transformed to numbers, edit one or two cells, replacing the numbers with text (such as `abc`) or blank (no number or text). You will need to change the `Data type` to `text` using the drop-down menu.
-> 2. Use the column pulldown menu to apply a numeric facet to the column you edited. The facet will appear in the left panel.
-> 3. Notice that there are several checkboxes in this facet: `Numeric`, `Non-numeric`, `Blank`, and `Error`. Below these checkboxes are counts of the number of cells in each category. You should see checks for `Non-numeric` and `Blank` if you changed some values.
-> 4. Experiment with checking or unchecking these boxes to select subsets of your data.
+> 1. For a column you transformed to numbers, edit one or two cells, replacing
+>    the numbers with text (such as `abc`) or blank (no number or text). You
+>    will need to change the `Data type` to `text` using the drop-down menu.
+> 2. Use the column pulldown menu to apply a numeric facet to the column you
+>    edited. The facet will appear in the left panel.
+> 3. Notice that there are several checkboxes in this facet: `Numeric`,
+>    `Non-numeric`, `Blank`, and `Error`. Below these checkboxes are counts of
+>    the number of cells in each category. You should see checks for
+>    `Non-numeric` and `Blank` if you changed some values.
+> 4. Experiment with checking or unchecking these boxes to select subsets of
+>    your data.
 {: .challenge}
 
-When done examining the numeric data, remove this facet by clicking the `x` in the upper left corner of its panel. Note that this does not undo the edits you made to the cells in this column. Use the `Undo / Redo` function to reverse these changes.
+When done examining the numeric data, remove this facet by clicking the `x` in
+the upper left corner of its panel. Note that this does not undo the edits you
+made to the cells in this column. Use the `Undo / Redo` function to reverse
+these changes.
 
 {% include links.md %}

--- a/_episodes/05-scripts.md
+++ b/_episodes/05-scripts.md
@@ -15,27 +15,45 @@ keypoints:
 
 ## How OpenRefine records what you have done
 
-As you conduct your data cleaning and preliminary analysis, OpenRefine saves every change you make to the dataset. These
-changes are saved in a format known as JSON (JavaScript Object Notation). You can export this JSON script and apply it to other data files. If you had 20 files to clean, and they all had the same type of errors (e.g. misspellings, leading white spaces), and all
-files had the same column names, you could save the JSON script, open a new file to clean in OpenRefine, paste in the script and run it.
-This gives you a quick way to clean all of your related data.
+As you conduct your data cleaning and preliminary analysis, OpenRefine saves
+every change you make to the dataset. These changes are saved in a format known
+as JSON (JavaScript Object Notation). You can export this JSON script and apply
+it to other data files. If you had 20 files to clean, and they all had
+the same type of errors (e.g. misspellings, leading white spaces), and all
+files had the same column names, you could save the JSON script, open a new
+file to clean in OpenRefine, paste in the script and run it. This gives you a
+quick way to clean all of your related data.
 
 ## Saving your work as a script
 
-1. In the `Undo / Redo` section, click `Extract...`, and select the steps that you want to apply to other datasets by clicking the check boxes.
+1. In the `Undo / Redo` section, click `Extract...`, and select the steps that
+   you want to apply to other datasets by clicking the check boxes.
 
-![History](../fig/history.png)
+   ![History](../fig/history.png)
 
-2. Copy the code from the right hand panel and paste it into a text editor (like NotePad on Windows or TextEdit on Mac). Make sure it saves as a plain text file. In TextEdit, do this by selecting `Format` > `Make plain text` and save the file as a `.txt` file.
+2. Copy the code from the right hand panel and paste it into a text editor
+   (like NotePad on Windows or TextEdit on Mac). Make sure it saves as a plain
+   text file. In TextEdit, do this by selecting `Format` > `Make plain text`
+   and save the file as a `.txt` file.
 
 ## Importing a script to use against another dataset
 
-Let's practice running these steps on a new dataset. We'll test this on an uncleaned version of the dataset we've been working with.
+Let's practice running these steps on a new dataset. We'll test this on an
+uncleaned version of the dataset we've been working with.
 
-1. Start a new project in OpenRefine using the messy dataset you downloaded before. Give the project a new name.  
-2. Click the `Undo / Redo` tab > `Apply` and paste in the contents of `.txt` file with the JSON code.
-3. Click `Perform operations`. The dataset should now be the same as your other cleaned dataset.
+1. Start a new project in OpenRefine using the messy dataset you downloaded
+   before. Give the project a new name.
+2. Click the `Undo / Redo` tab > `Apply` and paste in the contents of `.txt`
+   file with the JSON code.
+3. Click `Perform operations`. The dataset should now be the same as your other
+   cleaned dataset.
 
-For convenience, we used the same dataset. In reality you could use this process to clean related datasets. For example, data that you had collected over different fieldwork periods or data that was collected by different researchers (provided everyone uses the same column headings). The data in this file was generated from an eSurvey system with the actual survey being delivered centrally to a smartphone, so the column headings are pretty much guaranteed to be the same.
+For convenience, we used the same dataset. In reality you could use this
+process to clean related datasets. For example, data that you had collected
+over different fieldwork periods or data that was collected by different
+researchers (provided everyone uses the same column headings). The data in this
+file was generated from an eSurvey system with the actual survey being
+delivered centrally to a smartphone, so the column headings are pretty much
+guaranteed to be the same.
 
 {% include links.md %}

--- a/_episodes/06-saving.md
+++ b/_episodes/06-saving.md
@@ -14,44 +14,65 @@ keypoints:
 
 ## Saving and Exporting a Project
 
-In OpenRefine you can save or export the project. This means you're saving the data and all the 
-information about the cleaning and data transformation steps you've done. Once you've saved a project, you can
-open it up again and be just where you stopped before.
+In OpenRefine you can save or export the project. This means you're saving the
+data and all the information about the cleaning and data transformation steps
+you've done. Once you've saved a project, you can open it up again and be just
+where you stopped before.
 
 ### Saving
 
-By default OpenRefine is saving your project continuously. If you close OpenRefine and open it up again,
-you'll see a list of your projects. You can click on any one of them to open it up again.
+By default OpenRefine is saving your project continuously. If you close
+OpenRefine and open it up again, you'll see a list of your projects. You can
+click on any one of them to open it up again.
 
 ### Exporting
 
-You can also export a project. This is helpful, for instance, if you wanted to send your raw data and cleaning steps to a collaborator, 
-or share this information as a supplement to a publication. 
+You can also export a project. This is helpful, for instance, if you wanted to
+send your raw data and cleaning steps to a collaborator, or share this
+information as a supplement to a publication.
 
-1. Click the `Export` button in the top right and select `OpenRefine project archive to file`.
-2. A `tar.gz` file will download to your default `Download` directory. Depending on your browser you may have to confirm that you want to save the file. The `tar.gz` extension tells you that this is a compressed file.
-The downloaded `tar.gz` file is actually a folder of files which have been compressed. Linux and Mac machines will have software installed to automatically expand this type of file when you double-click on it. For Windows based machines you may have to install a utility like '7-zip' in order to expand the file and see the files in the folder. 
-3. After you have expanded the file look at the files that appear in this folder. What files are here? What information do you think these files contain?
+1. Click the `Export` button in the top right and select `OpenRefine project
+   archive to file`.
+2. A `tar.gz` file will download to your default `Download` directory.
+   Depending on your browser you may have to confirm that you want to save the
+   file. The `tar.gz` extension tells you that this is a compressed file. The
+   downloaded `tar.gz` file is actually a folder of files which have been
+   compressed. Linux and Mac machines will have software installed to
+   automatically expand this type of file when you double-click on it. For
+   Windows based machines you may have to install a utility like '7-zip' in
+   order to expand the file and see the files in the folder.
+3. After you have expanded the file look at the files that appear in this
+   folder. What files are here? What information do you think these files
+   contain?
 
 > ## Solution
 > You should see:
-> - a  `history` folder which contains a collection of  `zip` files. Each of these files itself contains a `change.txt` file. 
-> These `change.txt` files are the records of each individual transformation that you did to your data. 
-> - a `data.zip` file. When expanded, this `zip` file includes a file called `data.txt` which is a copy of your raw data.
-> You may also see other files.
+> - a `history` folder which contains a collection of  `zip` files. Each of
+>   these files itself contains a `change.txt` file. These `change.txt` files
+>   are the records of each individual transformation that you did to your
+>   data.
+> - a `data.zip` file. When expanded, this `zip` file includes a file called
+>   `data.txt` which is a copy of your raw data. You may also see other files.
 {: .solution}
 
-You can import an existing project into OpenRefine by clicking `Open...` in the upper right > `Import Project` and selecting the `tar.gz` 
-project file. This project will include all of the raw data and cleaning steps that were part of the original project.
+You can import an existing project into OpenRefine by clicking `Open...` in the
+upper right > `Import Project` and selecting the `tar.gz` project file. This
+project will include all of the raw data and cleaning steps that were part of
+the original project.
 
-## Exporting Cleaned Data 
+## Exporting Cleaned Data
 
 You can also export just your cleaned data, rather than the entire project.
 
-1. Click `Export` in the top right and select the file type you want to export the data in. `Tab-separated values` (`tsv`) or `Comma-separated values` (`csv`) would be good choices.
-2. That file will be exported to your default `Download` directory. That file can then be opened in a spreadsheet program or imported
-into programs like R or Python, which we'll be discussing later in our workshop.
+1. Click `Export` in the top right and select the file type you want to export
+   the data in. `Tab-separated values` (`tsv`) or `Comma-separated values`
+   (`csv`) would be good choices.
+2. That file will be exported to your default `Download` directory. That file
+   can then be opened in a spreadsheet program or imported into programs like R
+   or Python, which we'll be discussing later in our workshop.
 
-Remember from our lesson on Spreadsheets that using widely-supported, non-proprietary file formats like `tsv` or `csv` improves the ability of yourself and others to use your data. 
+Remember from our lesson on Spreadsheets that using widely-supported,
+non-proprietary file formats like `tsv` or `csv` improves the ability of
+yourself and others to use your data.
 
 {% include links.md %}

--- a/_episodes/07-resources.md
+++ b/_episodes/07-resources.md
@@ -13,21 +13,32 @@ keypoints:
 
 ## Using online resources to get help with OpenRefine
 
-OpenRefine is more than a simple data cleaning tool. People are using it for all sorts of activities. Here are some other resources that might prove useful.
+OpenRefine is more than a simple data cleaning tool. People are using it for
+all sorts of activities. Here are some other resources that might prove useful.
 
 OpenRefine has its own web site with documentation and a book:
 
 * [OpenRefine web site](https://openrefine.org/)
-* [OpenRefine User Manual](https://docs.openrefine.org/) (the previous [OpenRefine Wiki](https://github.com/OpenRefine/OpenRefine/wiki) is being phased out)
-* [Using OpenRefine](http://www.worldcat.org/title/using-openrefine-the-essential-openrefine-guide-that-takes-you-from-data-analysis-and-error-fixing-to-linking-your-dataset-to-the-web/oclc/889271264) book by Ruben Verborgh, Max De Wilde and Aniket Sawant
+* [OpenRefine User Manual](https://docs.openrefine.org/) (the previous
+  [OpenRefine Wiki]( https://github.com/OpenRefine/OpenRefine/wiki) is being phased out)
+* [Using OpenRefine](http://www.worldcat.org/title/
+using-openrefine-the-essential-openrefine-guide-that-takes-you-from-data-analysis-and-error-
+fixing-to-linking-your-dataset-to-the-web/oclc/889271264)
+  book by Ruben Verborgh, Max De Wilde and Aniket Sawant
 * [OpenRefine history from Wikipedia](https://en.wikipedia.org/wiki/OpenRefine)
 
 In addition, see these other useful resources:
 
-* [Grateful Data](https://github.com/scottythered/gratefuldata/wiki) is a fun site with many resources devoted to OpenRefine, including a nice tutorial.
-* [Margaret Heller](http://www.gloriousgeneralist.com/) shows how she uses OpenRefine for [Measuring and Counting Impact in Repositories](http://www.gloriousgeneralist.com/2014/12/notes-on-measuring-and-calculating-impact-in-institutional-repositories/).
+* [Grateful Data](https://github.com/scottythered/gratefuldata/wiki) is a fun
+  site with many resources devoted to OpenRefine, including a nice tutorial.
+* [Margaret Heller](http://www.gloriousgeneralist.com/) shows how she uses
+  OpenRefine for [Measuring and Counting Impact in Repositories](
+      http://www.gloriousgeneralist.com/2014/12/
+notes-on-measuring-and-calculating-impact-in-institutional-repositories/).
 
-There are more advanced uses of OpenRefine, such as bringing in column or cell data using web locators (URLs or APIs). The links above can give you a start on your journey.
+There are more advanced uses of OpenRefine, such as bringing in column or cell
+data using web locators (URLs or APIs). The links above can give you a start on
+your journey.
 
 > ## Exercise
 >

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -5,19 +5,29 @@ title: "Instructor Notes"
 
 ## Lesson
 
-This time allotted for the teaching and exercises in lessons one through eight in this episode totals 135 minutes. This does not include time for installing OpenRefine, which could take an extra 10-30 minutes depending on how many different platforms and how many computers need OpenRefine installed.
+This time allotted for the teaching and exercises in lessons one through eight
+in this episode totals 135 minutes. This does not include time for installing
+OpenRefine, which could take an extra 10-30 minutes depending on how many
+different platforms and how many computers need OpenRefine installed.
 
 ## Setup
 
-- There is a separate page with [setup instructions for installing OpenRefine]({{ page.root }}{% link setup.md %}).
-- If Internet Explorer is the default browser for participants, OpenRefine may have trouble opening. The URL can be copied and pasted into a Google Chrome or Firefox browser. Or, participants can be encouraged in advance of the workshop to set one of these two browsers as their default.
+- There is a separate page with [setup instructions for installing OpenRefine](
+    {{ page.root }}{% link setup.md %}).
+- If Internet Explorer is the default browser for participants, OpenRefine may
+  have trouble opening. The URL can be copied and pasted into a Google Chrome
+  or Firefox browser. Or, participants can be encouraged in advance of the
+  workshop to set one of these two browsers as their default.
 
 ## The datasets used
 
-- The dataset used in this lesson can be downloaded from Figshare through
- the link on the [setup page]({{ page.root }}{% link setup.md %}).
-- It will need to be downloaded to the local machine before it can be loaded into OpenRefine.
-- A general description of the dataset used in the Social Sciences lessons can be found [in the workshop data home page](http://www.datacarpentry.org/socialsci-workshop/data/)
+- The dataset used in this lesson can be downloaded from Figshare through the
+  link on the [setup page]({{ page.root }}{% link setup.md %}).
+- It will need to be downloaded to the local machine before it can be loaded
+  into OpenRefine.
+- A general description of the dataset used in the Social Sciences lessons can
+  be found [in the workshop data home page](
+      http://www.datacarpentry.org/socialsci-workshop/data/)
 
 ## The Lessons
 
@@ -29,12 +39,14 @@ This time allotted for the teaching and exercises in lessons one through eight i
 
 - Covers the creation of an OpenRefine project using our dataset.
 - The file has a single header row and is csv.
-- Facets and clustering are introduced and there is a discussion on the different clustering algorithms and how they may produce different results.
+- Facets and clustering are introduced and there is a discussion on the
+  different clustering algorithms and how they may produce different results.
 - Splitting columns is covered as is undo/redo.
 
 [Filtering and Sorting]({{ page.root }}{% link _episodes/03-filter-sort.md %})
 
-- Using Include and Exclude from a facet is covered and the difference between faceting and filtering is explained.
+- Using Include and Exclude from a facet is covered and the difference between
+  faceting and filtering is explained.
 - The various sort options for single or multiple columns is covered.
 
 [Examining Numbers in OpenRefine]({{ page.root }}{% link _episodes/04-numbers.md %})
@@ -44,12 +56,14 @@ This time allotted for the teaching and exercises in lessons one through eight i
 
 [Using scripts]({{ page.root }}{% link _episodes/05-scripts.md %})
 
-- Explains how actions within a project can be copied to an external file and re-applied. The same file is used to re-apply the changes.
+- Explains how actions within a project can be copied to an external file and
+  re-applied. The same file is used to re-apply the changes.
 
 [Saving results]({{ page.root }}{% link _episodes/06-saving.md %})
 
 - Covers the overall format of a project 'file' and how the components can be viewed.
-- This may require installing additional software on Windows machine (e.g. 7-zip) as the built-in un-zipping facility does not work with tar.gz files.
+- This may require installing additional software on Windows machine (e.g.
+  7-zip) as the built-in un-zipping facility does not work with tar.gz files.
 
 [Other resources in OpenRefine]({{ page.root }}{% link _episodes/07-resources.md %})
 

--- a/reference.md
+++ b/reference.md
@@ -4,39 +4,51 @@ layout: reference
 
 ## Glossary
 
-including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, Google Spreadsheets
+including tab separated (`tsv`), comma separated (`csv`), Excel
+(`xls`, `xlsx`), JSON, XML, RDF as XML, Google Spreadsheets
 
 {:auto_ids}
 
 csv
-:   A file extension indicating that a text file that has values separated by commas (comma-separated-values).
+:   A file extension indicating that a text file that has values separated by
+    commas (comma-separated-values).
 
 Clustering
-:   A method for finding different groups of values that may actually be representing the same thing.
+:   A method for finding different groups of values that may actually be
+    representing the same thing.
 
 Faceting
-:   A method for exploring the values in a variable. In this episode it is used to explore the values in order to identify errors in data entry.
+:   A method for exploring the values in a variable. In this episode it is used
+    to explore the values in order to identify errors in data entry.
 
 Filter
 :   To select a subset of data from a dataframe.
 
 JSON
-:   A file extension indicating that the values in a text file are structured using JavaScript Object Notation (JSON).
+:   A file extension indicating that the values in a text file are structured
+    using JavaScript Object Notation (JSON).
 
 RDF
-:   A file that extension indicating that the values in a file are structured using Resource Description Framework (RDF).
+:   A file that extension indicating that the values in a file are structured
+    using Resource Description Framework (RDF).
 
 Regular expressions (regex)
-:   A text string for describing a search pattern. They usually incorporate the use of wildcards to match letters, numbers, punctuation, spacing, or some combination.
+:   A text string for describing a search pattern. They usually incorporate the
+    use of wildcards to match letters, numbers, punctuation, spacing, or some
+    combination.
 
 tsv
-:   A file extension indicating that a text file that has values separated by tabs (tab-separated-values).
+:   A file extension indicating that a text file that has values separated by
+    tabs (tab-separated-values).
 
 xls
-:   A file extension indicating that a file is a spreadsheet created by Microsoft Excel.
+:   A file extension indicating that a file is a spreadsheet created by
+    Microsoft Excel.
 
 xlsx
-:   A file extension indicating that a file is a spreadsheet created by Microsoft Excel using XML.
+:   A file extension indicating that a file is a spreadsheet created by
+    Microsoft Excel using XML.
 
 XML
-:   A file extension indicating that the values in a file are structured using Extensible Markup Language (XML).
+:   A file extension indicating that the values in a file are structured using
+    Extensible Markup Language (XML).

--- a/setup.md
+++ b/setup.md
@@ -18,9 +18,10 @@ title: Setup
 > is a subset of the teaching version that has been intentionally 'messed up'
 > for this lesson.
 >
-> **Download** the data file to your computer by [clicking this link](https://ndownloader.figshare.com/files/11502815). (direct link: <https://ndownloader.figshare.com/files/11502815>)
+> **Download** the data file to your computer by
+  [clicking this link](https://ndownloader.figshare.com/files/11502815).
+  (direct link: <https://ndownloader.figshare.com/files/11502815>)
 {: .prereq}
-
 
 > ## Software
 >
@@ -35,39 +36,49 @@ title: Setup
 
 ### Windows
 
-- Check that you have Firefox, Edge, Opera or Chrome browsers installed and set as your
-default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
+- Check that you have Firefox, Edge, Opera or Chrome browsers installed and set
+  as your default browser. OpenRefine runs in your default browser. It will not
+  run correctly in Internet Explorer.
 - Download software from [https://openrefine.org](https://openrefine.org)
 - Unzip the downloaded file into a directory by right-clicking and
 selecting “Extract…”. Name that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
-- Click the openrefine.exe (this will launch a command prompt window, but you can ignore that and wait for the browser to launch)
-- If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
-- If you get a Java error when you try to open it you can try downloading [OpenRefine Windows kit with embedded Java](https://openrefine.org/download.html).
-
+- Click the openrefine.exe (this will launch a command prompt window, but you
+  can ignore that and wait for the browser to launch)
+- If you are using a different browser, or OpenRefine does not automatically
+  open for you, point your browser at [http://127.0.0.1:3333/](http://127.0.0.1:3333/) or
+  [http://localhost:3333](http://localhost:3333) to launch the program.
+- If you get a Java error when you try to open it you can try downloading
+  [OpenRefine Windows kit with embedded Java](https://openrefine.org/download.html).
 
 ### Mac
 
 - Check that you have Firefox, Edge, Opera or Chrome browsers installed and set as your
-default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
+  default browser. OpenRefine runs in your default browser. It will not run
+  correctly in Internet Explorer.
 - Download software from [https://openrefine.org](https://openrefine.org)
 - Unzip the downloaded file into a directory by double-clicking it. Name
 that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
-- Drag icon into Applications folder, and Control-click the app icon, then choose Open from the shortcut menu.
-For Troubleshooting help, see [the apple support page](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)
-- If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
+- Drag icon into Applications folder, and Control-click the app icon, then
+  choose Open from the shortcut menu. For Troubleshooting help, see
+  [the apple support page](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)
+- If you are using a different browser, or OpenRefine does not automatically
+  open for you, point your browser at [http://127.0.0.1:3333/](http://127.0.0.1:3333/) or
+  [http://localhost:3333](http://localhost:3333) to launch the program.
 
 ### Linux
 
 - Check that you have Firefox or Chrome browsers installed and set as your
-default browser. OpenRefine runs in your default browser. It will not run correctly in Internet Explorer.
+  default browser. OpenRefine runs in your default browser. It will not run
+  correctly in Internet Explorer.
 - Download software from [https://openrefine.org](https://openrefine.org)
-- Unzip the downloaded file into a directory. Name
-that directory something like OpenRefine.
+- Unzip the downloaded file into a directory. Name that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
 - Type ./refine into the terminal within the OpenRefine directory
-- If you are using a different browser, or OpenRefine does not automatically open for you, point your browser at http://127.0.0.1:3333/ or http://localhost:3333 to launch the program.
+- If you are using a different browser, or OpenRefine does not automatically
+  open for you, point your browser at [http://127.0.0.1:3333/](http://127.0.0.1:3333/) or
+  [http://localhost:3333](http://localhost:3333) to launch the program.


### PR DESCRIPTION
This PR removes a number of linter warnings relating to line length on markdown files, as detailed in #117.

In addition to the line length issues, a few other Markdown formatting changes have been made to address warnings raised when running [`markdownlint`](https://github.com/DavidAnson/markdownlint) on files locally (e.g. trailing spaces, multiple blank lines, ...).

Opening the PR to check that the changes are indeed resolving the warnings - currently a small group of files have been updated, the remainder will be updated in the coming days and additional commits with further changes pushed to this PR.

Closes #117

(Contributing to Hacktoberfest! - please add hacktoberfest-accepted tag as and when PR is accepted and merged 🎉 )