### PR TITLE
Add vendor directories to exclude to fix local dev deployment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ kind: "lesson"
 # Magic to make URLs resolve both locally and on GitHub.
 # See https://help.github.com/articles/repository-metadata-on-github-pages/.
 # Please don't change it: <USERNAME>/<PROJECT> is correct.
-repository: <USERNAME>/<PROJECT>
+repository: jcohen02/openrefine-socialsci
 
 # Email address, no mailto:
 email: "team@carpentries.org"
@@ -88,6 +88,9 @@ exclude:
   - Makefile
   - bin/
   - .Rproj.user/
+  - .vendor/
+  - vendor/
+  - .docker-vendor/
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ kind: "lesson"
 # Magic to make URLs resolve both locally and on GitHub.
 # See https://help.github.com/articles/repository-metadata-on-github-pages/.
 # Please don't change it: <USERNAME>/<PROJECT> is correct.
-repository: jcohen02/openrefine-socialsci
+repository: <USERNAME>/<PROJECT>
 
 # Email address, no mailto:
 email: "team@carpentries.org"


### PR DESCRIPTION
As described in issue #124, this PR updates the config file to exclude the processing of vendor directories which causes an error when trying to run the site locally via jekyll for development purposes.

This updates the config to mirror the excluded directories in the [latest version of the config file](https://github.com/carpentries/workshop-template/blob/gh-pages/_config.yml) in the carpentries workshop-template repo.

Closes #124