### PR TITLE
Add Contributing to README, update CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
-[Software Carpentry][swc-site] and [Data Carpentry][dc-site] are open source projects,
+[The Carpentries][c-site] ([Software Carpentry][swc-site], [Data Carpentry][dc-site],
+and [Library Carpentry][lc-site]) are open source projects,
 and we welcome contributions of all kinds:
 new lessons,
 fixes to existing material,
@@ -14,8 +15,8 @@ you agree that we may redistribute your work under [our license](LICENSE.md).
 In exchange,
 we will address your issues and/or assess your change proposal as promptly as we can,
 and help you become a member of our community.
-Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-agrees to abide by our [code of conduct](CONDUCT.md).
+Everyone involved in [The Carpentries][c-site]
+agrees to abide by our [code of conduct](CODE_OF_CONDUCT.md).
 
 ## How to Contribute
 
@@ -34,7 +35,7 @@ and to meet some of our community members.
 2.  If you have a [GitHub][github] account,
     or are willing to [create one][github-join],
     but do not know how to use Git,
-    you can report problems or suggest improvements by [creating an issue][issues].
+    you can report problems or suggest improvements by [creating an issue][gh-issues].
     This allows us to assign the item to someone
     and to respond to it in a threaded discussion.
 
@@ -69,17 +70,17 @@ and to meet some of our community members.
 There are many ways to contribute,
 from writing new exercises and improving existing ones
 to updating or filling in the documentation
-and and submitting [bug reports][issues]
-about things that don't work, aren't clear, or are missing.
-If you are looking for ideas,
-please see [the list of issues for this repository][issues],
-or the issues for [Data Carpentry][dc-issues]
-and [Software Carpentry][swc-issues] projects.
+and submitting [bug reports][gh-issues]
+about things that do not work, are not clear, or are missing.
+If you are looking for ideas, please see the
+list of [issues associated with this repository][issues],
+or you may also look at all issues for [Data Carpentry][dc-issues],
+[Software Carpentry][swc-issues], and [Library Carpentry][lc-issues] projects.
 
 Comments on issues and reviews of pull requests are just as welcome:
 we are smarter together than we are on our own.
 Reviews from novices and newcomers are particularly valuable:
-it's easy for people who have been using these lessons for a while
+it is easy for people who have been using these lessons for a while
 to forget how impenetrable some of this material can be,
 so fresh eyes are always welcome.
 
@@ -101,51 +102,55 @@ our lessons must run equally well on all three.
 
 ## Using GitHub
 
-If you choose to contribute via GitHub,
-you may want to look at
-[How to Contribute to an Open Source Project on GitHub][how-contribute].
-In brief:
+If you choose to contribute via GitHub, you may want to look at
+[How to Contribute to an Open Source Project on GitHub][contribute].
+To manage changes, we follow [GitHub flow][github-flow].
+Each lesson has at least two maintainers who review issues and pull requests or encourage others to
+do so.
+The maintainers are community volunteers and have final say over what gets merged into the lesson.
+To use the web interface for contributing to a lesson:
 
-1.  The published copy of the lesson is in the `gh-pages` branch of the repository
-    (so that GitHub will regenerate it automatically).
-    Please create all branches from that,
-    and merge the [master repository][repo]'s `gh-pages` branch into your `gh-pages` branch
-    before starting work.
-    Please do *not* work directly in your `gh-pages` branch,
-    since that will make it difficult for you to work on other contributions.
+1. Fork the originating repository to your GitHub profile.
+2. Within your version of the forked repository, move to the `gh-pages` branch and
+   create a new branch for each significant change being made.
+3. Navigate to the file(s) you wish to change within the new branches and make revisions as
+   required.
+4. Commit all changed files within the appropriate branches.
+5. Create individual pull requests from each of your changed branches
+   to the `gh-pages` branch within the originating repository.
+6. If you receive feedback, make changes using your issue-specific branches of the forked
+   repository and the pull requests will update automatically.
+7. Repeat as needed until all feedback has been addressed.
 
-2.  We use [GitHub flow][github-flow] to manage changes:
-    1.  Create a new branch in your desktop copy of this repository for each significant change.
-    2.  Commit the change in that branch.
-    3.  Push that branch to your fork of this repository on GitHub.
-    4.  Submit a pull request from that branch to the [master repository][repo].
-    5.  If you receive feedback,
-        make changes on your desktop and push to your branch on GitHub:
-        the pull request will update automatically.
-
-Each lesson has two maintainers who review issues and pull requests
-or encourage others to do so.
-The maintainers are community volunteers,
-and have final say over what gets merged into the lesson.
+When starting work, please make sure your clone of the originating `gh-pages` branch is up-to-date
+before creating your own revision-specific branch(es) from there.
+Additionally, please only work from your newly-created branch(es) and *not*
+your clone of the originating `gh-pages` branch.
+Lastly, published copies of all the lessons are available in the `gh-pages` branch of the
+originating repository for reference while revising.
 
 ## Other Resources
 
-General discussion of [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-happens on the [discussion mailing list][discuss-list],
+General discussion of [Software Carpentry][swc-site], [Data Carpentry][dc-site], and
+[Library Carpentry][lc-site] happens on the [discussion mailing list][discuss-list],
 which everyone is welcome to join.
 You can also [reach us by email][contact].
 
-[contact]: mailto:admin@software-carpentry.org
+[contact]: mailto:team@software-carpentry.org
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
-[dc-lessons]: http://datacarpentry.org/lessons/
-[dc-site]: http://datacarpentry.org/
-[discuss-list]: http://lists.software-carpentry.org/listinfo/discuss
-[github]: http://github.com
+[dc-lessons]: https://datacarpentry.org/lessons/
+[dc-site]: https://datacarpentry.org/
+[discuss-list]: https://carpentries.topicbox.com/groups/discuss
+[github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[gh-issues]: https://guides.github.com/features/issues/
+[contribute]: https://app.egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/datacarpentry/openrefine-socialsci/issues/
 [repo]: https://github.com/datacarpentry/openrefine-socialsci/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/
-[swc-site]: http://software-carpentry.org/
+[swc-site]: https://software-carpentry.org/
+[c-site]: https://carpentries.org/
+[lc-site]: https://librarycarpentry.org/
+[lc-issues]: https://github.com/issues?q=user%3Alibrarycarpentry

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
         https://swcarpentry.slack.com/messages/C9Y0UEXPY)
 [![DOI](https://zenodo.org/badge/92422790.svg)](https://zenodo.org/badge/latestdoi/92422790)
 
-# openrefine-socialsci
+# OpenRefine for Social Sciences
 
-Lesson on OpenRefine for social scientists.
+This is a Data Carpentry lesson on OpenRefine for social scientists.
 Please see <https://datacarpentry.org/openrefine-socialsci/> for a rendered version of this lesson.
 
 This is an introduction to OpenRefine designed for participants with no previous experience.
@@ -17,9 +17,71 @@ The episodes in this lesson cover introductory topics related to using OpenRefin
 
 The [instructor notes][in] contain some tips about how to best teach this workshop.
 
+## Contributing
+
+We welcome all contributions to improve the lesson!
+The [maintainers](#maintainers) will do their best to help you if you have any
+questions, concerns, or experience any difficulties along the way.
+
+We'd like to ask you to familiarize yourself with our [Contribution Guide](CONTRIBUTING.md) and
+have a look at the [more detailed guidelines][lesson-example] on proper formatting, ways to render
+the lesson locally, and even how to write new episodes.
+
+Please see the current list of [issues][ghri] for ideas for contributing to this lesson.
+For making your contribution, we use the [GitHub flow][github-flow].
+Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg).
+This indicates that the maintainers will welcome a pull request fixing this issue.
+
+### Making changes to the contents
+
+*Please read [Contributing](CONTRIBUTING.md) before starting the work.
+This section and the next are only a very brief introduction to providing changes.*
+
+This lesson website is built from Markdown files using the Jekyll static site generator.
+The episodes that make up this lesson are in the `_episodes` directory.
+If you want to create a pull request (PR) with changes in any of the episodes or other Markdown
+files, it helps if you can preview the results of your changes before you submit the PR.
+This is explained in the next section.
+
+The [lesson example][lesson-example] explains all the steps needed to create and update a lesson
+like this one.
+
+### Previewing the lesson on your computer
+
+*This is helpful for submitting a pull request, but not required.*
+
+Please see the [instructions on setting up your computer for previewing the lesson][setup].
+Previewing the lesson requires Ruby and the `bundler` gem;
+if you have [Make][make], the commands become shorter.
+
+To preview any changes on your own computer, you may either:
+
+- use [GNU Make][make]: `make serve` or `make site`; or
+- use Jekyll directly:
+    1. `bundle config set --local path .vendor/bundle && bundle install && bundle update`
+    2. `bundle exec jekyll serve` or `bundle exec jekyll build`
+
+The `serve` commands start a webserver that updates the output every time you save a file.
+The `site`/`build` commands only create the HTML output in the `_site` directory.
+
+See [Checking and Previewing][check] for more information on previewing your changes,
+as well as commands for running various checks.
+
 ## Maintainers
+
+The current maintainers of this lesson are:
 
 - [Ben Companjen](https://github.com/bencomp)
 - [Emilia Gan](https://github.com/efran)
 
+They can usually be reached in our [Slack channel] and through [issues in the GitHub
+repository][ghri].
+
 [in]: https://datacarpentry.org/openrefine-socialsci/guide/
+[Slack channel]: https://swcarpentry.slack.com/messages/C9Y0UEXPY
+[lesson-example]: https://carpentries.github.io/lesson-example/
+[ghri]: https://github.com/datacarpentry/openrefine-socialsci/issues
+[github-flow]: https://guides.github.com/introduction/flow/
+[setup]: https://carpentries.github.io/lesson-example/setup.html
+[make]: https://www.gnu.org/software/make/
+[check]: https://carpentries.github.io/lesson-example/07-checking/index.html

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,7 +1,7 @@
 {% include base_path.html %}
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
-[ci]: http://communityin.org/
+[ci]: https://communityin.org/
 [coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
 [coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
 [concept-maps]: https://carpentries.github.io/instructor-training/05-memory/
@@ -10,13 +10,13 @@
 [cran-checkpoint]: https://cran.r-project.org/package=checkpoint
 [cran-knitr]: https://cran.r-project.org/package=knitr
 [cran-stringr]: https://cran.r-project.org/package=stringr
-[dc-lessons]: http://www.datacarpentry.org/lessons/
+[dc-lessons]: https://datacarpentry.org/lessons/
 [email]: mailto:team@carpentries.org
 [github-importer]: https://import2.github.com/
 [importer]: https://github.com/new/import
 [jekyll-collection]: https://jekyllrb.com/docs/collections/
 [jekyll-install]: https://jekyllrb.com/docs/installation/
-[jekyll-windows]: http://jekyll-windows.juthilo.com/
+[jekyll-windows]: https://jekyll-windows.juthilo.com/
 [jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
 [kramdown]: https://kramdown.gettalong.org/
@@ -46,4 +46,4 @@
 [swc-releases]: https://github.com/swcarpentry/swc-releases
 [training]: https://carpentries.github.io/instructor-training/
 [workshop-repo]: {{ site.workshop_repo }}
-[yaml]: http://yaml.org/
+[yaml]: https://yaml.org/


### PR DESCRIPTION
This closes #126 by:

- updating the contribution guide `CONTRIBUTING.md`, based on the updated boilerplate guide;
- adding references to this guide with a more technical quickstart to the README.

Additionally, I updated HTTP URLs to HTTPS URLs in `_includes/links.md` and changed a bit of the existing wording in the README.