### PR TITLE
Warn about anti-malware software blocking OpenRefine

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -14,6 +14,8 @@ different platforms and how many computers need OpenRefine installed.
 
 - There is a separate page with [setup instructions for installing OpenRefine](
     {{ page.root }}{% link setup.md %}).
+- Participants should install and run before the workshop, so that any problems
+  may reveal themselves early.
 - If Internet Explorer is the default browser for participants, OpenRefine may
   have trouble opening. The URL can be copied and pasted into a Google Chrome
   or Firefox browser. Or, participants can be encouraged in advance of the

--- a/setup.md
+++ b/setup.md
@@ -25,7 +25,9 @@ title: Setup
 > ## Software
 >
 > For this lesson you will need **OpenRefine** (formerly Google Refine) and a
-> web browser.
+> web browser. Basic installation steps are provided on this page.
+> The OpenRefine [installation manual](https://openrefine.org/docs/manual/installing)
+> provides more details about installation, upgrades and configuration.
 >
 > Note: this is a Java program that runs on your machine (not in the cloud).
 > It runs inside your browser, but no web connection is needed for this lesson.

--- a/setup.md
+++ b/setup.md
@@ -18,9 +18,8 @@ title: Setup
 > is a subset of the teaching version that has been intentionally 'messed up'
 > for this lesson.
 >
-> **Download** the data file to your computer by
-  [clicking this link](https://ndownloader.figshare.com/files/11502815).
-  (direct link: <https://ndownloader.figshare.com/files/11502815>)
+> [**Download** the data file](https://ndownloader.figshare.com/files/11502815)
+> to your computer.
 {: .prereq}
 
 > ## Software

--- a/setup.md
+++ b/setup.md
@@ -31,9 +31,12 @@ title: Setup
 >
 > Note: this is a Java program that runs on your machine (not in the cloud).
 > It runs inside your browser, but no web connection is needed for this lesson.
-> You do not need administrative rights on the computer to *install* OpenRefine.
-> However, you may need administrative rights to allow OpenRefine to *run* if
-> anti-malware software blocks the application. OpenRefine is safe to run.
+>
+> > You do not need administrative rights on the computer to *install* OpenRefine.
+> > However, if anti-malware software blocks OpenRefine when you try to start it,
+> > you may need administrative rights to allow OpenRefine to *run*.
+> > OpenRefine is safe to run.
+> {: .callout}
 >
 {: .prereq}
 
@@ -45,9 +48,10 @@ title: Setup
 - Download the software from [openrefine.org](https://openrefine.org).
 - Unzip the downloaded file into a directory by right-clicking and
   selecting “Extract…”. Name that directory something like OpenRefine.  
-  (Note that the path to the directory you extract the application files into should be
-  short, because some of OpenRefine's files have very long names. If the path is
-  too long, OpenRefine cannot start.)
+  > The path to the directory you extract the application files into should be
+  > short, because some of OpenRefine's files have very long names. If the path is
+  > too long, OpenRefine cannot start.
+  {: .callout}
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine by opening `openrefine.exe`. This will launch a command prompt window,
   but you can ignore that and wait for the browser to launch.

--- a/setup.md
+++ b/setup.md
@@ -30,7 +30,9 @@ title: Setup
 >
 > Note: this is a Java program that runs on your machine (not in the cloud).
 > It runs inside your browser, but no web connection is needed for this lesson.
-> You do not need administrative rights on the computer to use OpenRefine.
+> You do not need administrative rights on the computer to *install* OpenRefine.
+> However, you may need administrative rights to allow OpenRefine to *run* if
+> anti-malware software blocks the application. OpenRefine is safe to run.
 >
 {: .prereq}
 

--- a/setup.md
+++ b/setup.md
@@ -41,20 +41,19 @@ title: Setup
 - Check that you have Firefox, Edge, Opera or Chrome browsers installed and set
   as your default browser. OpenRefine runs in your default browser. It will not
   run correctly in Internet Explorer.
-- Download software from [https://openrefine.org](https://openrefine.org)
+- Download the software from [openrefine.org](https://openrefine.org).
 - Unzip the downloaded file into a directory by right-clicking and
-selecting “Extract…”. Name that directory something like OpenRefine.
+  selecting “Extract…”. Name that directory something like OpenRefine.  
   (Note that the path to the directory you extract the application files into should be
   short, because some of OpenRefine's files have very long names. If the path is
   too long, OpenRefine cannot start.)
 - Go to your newly created OpenRefine directory.
-- Launch OpenRefine
-- Click the openrefine.exe (this will launch a command prompt window, but you
-  can ignore that and wait for the browser to launch)
-- If you are using a different browser, or OpenRefine does not automatically
-  open for you, point your browser at [http://127.0.0.1:3333/](http://127.0.0.1:3333/) or
-  [http://localhost:3333](http://localhost:3333) to launch the program.
-- If you get a Java error when you try to open it you can try downloading
+- Launch OpenRefine by opening `openrefine.exe`. This will launch a command prompt window,
+  but you can ignore that and wait for the browser to launch.
+- If you see Internet Explorer start, or OpenRefine does not automatically
+  open for you, point one of the supported browsers at <http://127.0.0.1:3333/> or
+  <http://localhost:3333> to launch the program.
+- If you get a Java error when you try to open it, you can try downloading the
   [OpenRefine Windows kit with embedded Java](https://openrefine.org/download.html).
 
 ### Mac
@@ -62,28 +61,26 @@ selecting “Extract…”. Name that directory something like OpenRefine.
 - Check that you have Firefox, Edge, Opera or Chrome browsers installed and set as your
   default browser. OpenRefine runs in your default browser. It will not run
   correctly in Internet Explorer.
-- Download software from [https://openrefine.org](https://openrefine.org)
+- Download the software from [openrefine.org](https://openrefine.org).
 - Unzip the downloaded file into a directory by double-clicking it. Name
-that directory something like OpenRefine.
+  that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
-- Launch OpenRefine
-- Drag icon into Applications folder, and Control-click the app icon, then
-  choose Open from the shortcut menu. For Troubleshooting help, see
-  [the apple support page](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)
-- If you are using a different browser, or OpenRefine does not automatically
-  open for you, point your browser at [http://127.0.0.1:3333/](http://127.0.0.1:3333/) or
-  [http://localhost:3333](http://localhost:3333) to launch the program.
+- Drag the OpenRefine app into the Applications folder.
+- Launch OpenRefine: Control-click the app icon, then
+  choose "Open" from the shortcut menu. For Troubleshooting help, see
+  [the Apple support page](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac).
+- If you are using a different browser than listed above, or if OpenRefine does not automatically
+  open for you, point your browser at <http://127.0.0.1:3333/> or
+  <http://localhost:3333> to launch the program.
 
 ### Linux
 
 - Check that you have Firefox or Chrome browsers installed and set as your
-  default browser. OpenRefine runs in your default browser. It will not run
-  correctly in Internet Explorer.
-- Download software from [https://openrefine.org](https://openrefine.org)
+  default browser. OpenRefine runs in your default browser.
+- Download the software from [openrefine.org](https://openrefine.org).
 - Unzip the downloaded file into a directory. Name that directory something like OpenRefine.
 - Go to your newly created OpenRefine directory.
-- Launch OpenRefine
-- Type ./refine into the terminal within the OpenRefine directory
-- If you are using a different browser, or OpenRefine does not automatically
-  open for you, point your browser at [http://127.0.0.1:3333/](http://127.0.0.1:3333/) or
-  [http://localhost:3333](http://localhost:3333) to launch the program.
+- Launch OpenRefine by typing `./refine` into the terminal within the OpenRefine directory.
+- If you are using a different browser than listed above, or if OpenRefine does not automatically
+  open for you, point your browser at <http://127.0.0.1:3333/> or
+  <http://localhost:3333> to launch the program.

--- a/setup.md
+++ b/setup.md
@@ -44,6 +44,9 @@ title: Setup
 - Download software from [https://openrefine.org](https://openrefine.org)
 - Unzip the downloaded file into a directory by right-clicking and
 selecting “Extract…”. Name that directory something like OpenRefine.
+  (Note that the path to the directory you extract the application files into should be
+  short, because some of OpenRefine's files have very long names. If the path is
+  too long, OpenRefine cannot start.)
 - Go to your newly created OpenRefine directory.
 - Launch OpenRefine
 - Click the openrefine.exe (this will launch a command prompt window, but you


### PR DESCRIPTION
Fixes #132. This adds a suggestion for instructors (to relay to workshop organisers) about checking the installation early and adds a caveat to the setup instructions about needing admin rights for unblocking OpenRefine in anti-malware software.

I'm not sure that this is enough or that this is the best way to describe the issue/solution. Open for alternative phrasing or additions!