### PR TITLE
Move instructor notes inline and add some more

### DIFF
--- a/episodes/01-introduction.md
+++ b/episodes/01-introduction.md
@@ -19,6 +19,28 @@ exercises: 0
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+::::: instructor
+
+## Please help improve this page
+
+There are several issues related to this section of the lesson:
+
+- [the goals of the (whole) lesson should be stated (#38)][issue-38]
+- [it does not explain the difference between data cleaning and data organisation (#56)][issue-56]
+- [the contents do not match the objectives (#86)][issue-86]
+- [it does not explain when (not) to use OpenRefine (#103)][issue-103]
+- [the Getting Help section should move to the end or an Extras page (#122)][issue-122]
+
+[issue-38]: https://github.com/datacarpentry/openrefine-socialsci/issues/38
+[issue-56]: https://github.com/datacarpentry/openrefine-socialsci/issues/56
+[issue-86]: https://github.com/datacarpentry/openrefine-socialsci/issues/86
+[issue-103]: https://github.com/datacarpentry/openrefine-socialsci/issues/103
+[issue-122]: https://github.com/datacarpentry/openrefine-socialsci/issues/122
+
+Your input on these issues would be much appreciated!
+
+::::::::::::::::
+
 ## Motivations for the OpenRefine Lesson
 
 - Data is often very messy. OpenRefine provides a set of tools to allow you to

--- a/episodes/02-working-with-openrefine.md
+++ b/episodes/02-working-with-openrefine.md
@@ -42,6 +42,21 @@ countries in eastern sub-Saharan Africa (Mozambique and Tanzania).
 If you haven't yet downloaded the data, see the [instructions on downloading
 the data in Setup](../learners/setup.md).
 
+::: instructor
+
+### Importing the sample data
+
+The file has a single header row and has comma-separated values.
+OpenRefine should not have trouble figuring out the settings for parsing these
+data. Either US-ASCII or UTF-8 are fine as character encoding.
+
+Consider giving the project a meaningful name. If you do, briefly explain how
+that name is meaningful (to you and hopefully others).
+
+There are many columns in the file, which may be handled after importing.
+
+::::::::::::::
+
 Once OpenRefine is launched in your browser, the left margin has options to
 `Create Project`, `Open Project`, or `Import Project`. Here we will create a
 new project:

--- a/episodes/02-working-with-openrefine.md
+++ b/episodes/02-working-with-openrefine.md
@@ -175,17 +175,17 @@ of entries for each date.
 
 Most of the data was collected in November of 2016.
 
-
-
 :::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 ## More on Facets
 
-[OpenRefine Manual: Facets](https://docs.openrefine.org/manual/facets)
+
+[OpenRefine Manual: Facets](https://openrefine.org/docs/manual/facets)
 
 As well as 'Text facets' Refine also supports a range of other types of
 facet. These include:
@@ -217,7 +217,6 @@ default custom facets are:
 - Facet by blank - a binary facet of 'true' or 'false'. Rows appear in the
   'true' facet if they have no data present in that column. This is useful
   when looking for rows missing key data.
-  
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -298,8 +297,6 @@ right square brackets (`]`), and spaces from the `items_owned` column.
 2. `value.replace("]", "")`
 3. `value.replace(" ", "")`
   You should now have a list of items separated by semi-colons (`;`).
-  
-  
 
 :::::::::::::::::::::::::
 
@@ -330,11 +327,10 @@ least commonly owned?
 Select `Sort by:` `count`. The most commonly owned items are
 mobile phone and radio, the least commonly owned are cars and computers.
 
-
-
 :::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
@@ -354,11 +350,10 @@ statements. The command is:
 This can also be done in four separate steps if preferred.
 November was the most common month for respondents to lack food.
 
-
-
 :::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 

--- a/index.md
+++ b/index.md
@@ -16,7 +16,6 @@ data and automatically track any changes that you make. Many people comment
 that this tool saves them literally months of work trying to make these
 edits by hand.
 
-::::::::::::::::::::::::::::::::::::::::::  prereq
 
 ## Getting Started
 
@@ -26,28 +25,6 @@ workflow.
 
 **These lessons assume no prior knowledge of the skills or tools.**
 
-To get started, follow the directions in the "[Setup](learners/setup.md)" tab to
-download data to your computer and follow any installation instructions.
-
-#### Prerequisites
-
-This lesson requires a working copy of OpenRefine (also called
-GoogleRefine).
-
 To most effectively use these materials, please make sure to install
 everything *before* working through this lesson.
-
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-::::::::::::::::::::::::::::::::::::::::::  prereq
-
-## For Instructors
-
-If you are teaching this lesson in a workshop, please see the
-[Instructor notes](instructors/instructor-notes.md).
-
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
 

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -2,32 +2,19 @@
 title: Instructor Notes
 ---
 
-## Lesson
-
-This time allotted for the teaching and exercises in lessons one through eight
-in this episode totals 135 minutes. This does not include time for installing
-OpenRefine, which could take an extra 10-30 minutes depending on how many
-different platforms and how many computers need OpenRefine installed.
-
 ## Setup
 
-- There is a separate page with [setup instructions for installing OpenRefine](
-  ../learners/setup.md).
-- Participants should install and run before the workshop, so that any problems
-  may reveal themselves early.
-- If Internet Explorer is the default browser for participants, OpenRefine may
-  have trouble opening. The URL can be copied and pasted into a Google Chrome
-  or Firefox browser. Or, participants can be encouraged in advance of the
-  workshop to set one of these two browsers as their default.
+Participants should install and run before the workshop, so that any problems
+may reveal themselves early.
 
-## The datasets used
+## The dataset used
 
 - The dataset used in this lesson can be downloaded from Figshare through the
-  link on the [setup page](../learners/setup.md).
+  link in the [setup section](../learners/setup.md).
 - It will need to be downloaded to the local machine before it can be loaded
   into OpenRefine.
 - A general description of the dataset used in the Social Sciences lessons can
-  be found [in the workshop data home page](https://www.datacarpentry.org/socialsci-workshop/data/)
+  be found [in the workshop data home page](https://datacarpentry.org/socialsci-workshop/data/).
 
 ## The Lessons
 
@@ -38,7 +25,6 @@ different platforms and how many computers need OpenRefine installed.
 [Working with OpenRefine](../episodes/02-working-with-openrefine.md)
 
 - Covers the creation of an OpenRefine project using our dataset.
-- The file has a single header row and is csv.
 - Facets and clustering are introduced and there is a discussion on the
   different clustering algorithms and how they may produce different results.
 - Splitting columns is covered as is undo/redo.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -33,15 +33,23 @@ to your computer.
 
 ::: instructor
 
-### About the data / Import from URL
+### About the data
 
 A general description of the dataset used in the Social Sciences lessons can
 be found [in the workshop data home page](https://www.datacarpentry.org/socialsci-workshop/data/).
+
+::::::::::::::
+
+
+::: instructor
+
+### Import from URL
 
 Instead of downloading the data to the computer, you could import the data from
 the URL directly when you start the project.
 When learners have trouble finding the file on their computer, this may be a
 workaround to not have to wait.
+
 ::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,6 +2,15 @@
 title: Setup
 ---
 
+::: instructor
+
+## Install and run before workshop
+
+Participants should install and run before the workshop, so that any problems
+may reveal themselves early.
+
+::::::::::::::
+
 ::::::::::::::::::::::::::::::::::::::::::  prereq
 
 ## Data
@@ -22,6 +31,18 @@ for this lesson.
 [**Download** the data file](https://ndownloader.figshare.com/files/11502815)
 to your computer.
 
+::: instructor
+
+### About the data / Import from URL
+
+A general description of the dataset used in the Social Sciences lessons can
+be found [in the workshop data home page](https://www.datacarpentry.org/socialsci-workshop/data/).
+
+Instead of downloading the data to the computer, you could import the data from
+the URL directly when you start the project.
+When learners have trouble finding the file on their computer, this may be a
+workaround to not have to wait.
+::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -37,17 +58,28 @@ provides more details about installation, upgrades and configuration.
 Note: this is a Java program that runs on your machine (not in the cloud).
 It runs inside your browser, but no web connection is needed for this lesson.
 
-:::::::::::::::::::::::::::::::::::::::::  callout
+::::::::::::::::::::::::::::::::::::::  callout
+
+### Administrator rights
 
 You do not need administrative rights on the computer to *install* OpenRefine.
 However, if anti-malware software blocks OpenRefine when you try to start it,
 you may need administrative rights to allow OpenRefine to *run*.
 OpenRefine is safe to run.
 
+:::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-::::::::::::::::::::::::::::::::::::::::::::::::::
+::: instructor
+
+### Long startup duration
+
+Starting OpenRefine may take minutes, even on some modern computers.
+Learners may be wondering if it is actually working; if there are no error messages,
+it is probably still starting up and you should wait a little longer.
+
+::::::::::::::
 
 ### Windows
 
@@ -59,6 +91,8 @@ OpenRefine is safe to run.
    selecting "Extract…". Name that directory something like OpenRefine.
    
    :::::::::::::::::::::::::::::::::::::::::  callout
+   #### Long paths
+
    The path to the directory you extract the application files into should be
    short, because some of OpenRefine's files have very long names. If the path is
    too long, OpenRefine cannot start.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -91,6 +91,7 @@ it is probably still starting up and you should wait a little longer.
    selecting "Extract…". Name that directory something like OpenRefine.
    
    :::::::::::::::::::::::::::::::::::::::::  callout
+
    #### Long paths
 
    The path to the directory you extract the application files into should be


### PR DESCRIPTION
This fixes #146. Some notes from the instructor notes page are now inline notes, though some general notes are still in the separate page. All instructor notes and callouts now have a heading, to allow assessing their value without having to view the contents first.

The Introduction episode (or chapter) now starts with a call for contributions from instructors with links to issues.

Since the index.md and setup.md files are merged into the front page of the lesson, some references had to be removed or updated to make sense in the new context.