### PR TITLE
Add instructor note on Open Project

### DIFF
--- a/episodes/02-working-with-openrefine.md
+++ b/episodes/02-working-with-openrefine.md
@@ -57,6 +57,18 @@ There are many columns in the file, which may be handled after importing.
 
 ::::::::::::::
 
+
+::: instructor
+
+### Open Project if accidentally back at start screen
+
+If at any time you (accidentally) end up back at the start screen, you could
+demonstrate "Open Project".
+It opens your project where you were, which demonstrates that OpenRefine
+continually saves the project in the background.
+
+::::::::::::::
+
 Once OpenRefine is launched in your browser, the left margin has options to
 `Create Project`, `Open Project`, or `Import Project`. Here we will create a
 new project:

--- a/episodes/02-working-with-openrefine.md
+++ b/episodes/02-working-with-openrefine.md
@@ -60,10 +60,10 @@ There are many columns in the file, which may be handled after importing.
 
 ::: instructor
 
-### Open Project if accidentally back at start screen
+### Open Project when you returned to start screen
 
-If at any time you (accidentally) end up back at the start screen, you could
-demonstrate "Open Project".
+If at any time during the lesson you (accidentally) end up back at the start screen,
+you could demonstrate "Open Project".
 It opens your project where you were, which demonstrates that OpenRefine
 continually saves the project in the background.
 

--- a/episodes/02-working-with-openrefine.md
+++ b/episodes/02-working-with-openrefine.md
@@ -245,6 +245,20 @@ default custom facets are:
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+
+::::: callout
+
+### Bookmark a project with facets and filters
+
+OpenRefine saves the project continuously so that you can close the browser
+and use "Open Project" from the start page to continue the work.
+However, any facets and filters (discussed in the next episode) are not saved.
+To save the exact view, you can bookmark the "Permalink" that is to the right
+of the project name in the top left corner of the screen.
+
+:::::::::::::
+
+
 ## Using clustering to detect possible typing errors
 
 In OpenRefine, clustering means "finding groups of different values that might


### PR DESCRIPTION
Based on experience in which the instructor scrolled a bit too hard, causing the browser to go back in history. This meant that suddenly the "opening window" showed.

This was a nice opportunity to demonstrate that OpenRefine continually saves the progress. (Though it doesn't store the facets and filter settings.)