### PR TITLE
Add note on screen size and zooming

### DIFF
--- a/episodes/01-introduction.md
+++ b/episodes/01-introduction.md
@@ -110,7 +110,22 @@ you can find a lot of help. As with other programs of this type, OpenRefine
 libraries are available too, where you can find a script you need and copy it
 into your OpenRefine instance to run it on your dataset.
 
+::: instructor
 
+### Zooming hides buttons
+
+OpenRefine is used through its graphical user interface in this lesson.
+In classroom settings or in online classes, you probably want to zoom in on the
+interface so that text is readable to all.
+However, when you zoom in, some controls may fall outside the view.
+Dialog windows in OpenRefine cannot be dragged, so the only way to show buttons
+that were outside the view is to zoom out again.
+
+If you are planning to teach this lesson to a big room, you may want to check
+if the main projector screen or monitor is large enough to show all of the
+user interface while having the text large enough that all learners can see it.
+
+::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
Noted during a workshop: in a room in which the monitor at the front of the room is not very big, the instructor needed to zoom in to allow learners in the back to read the text. But that often meant that some buttons went out of the view.

This note is a reminder that this may happen when you zoom in, as well as something to check with the host before the workshop.