### PR TITLE
Set the url to datacarpentry.org, update keywords in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,7 +58,7 @@ contact: 'team@carpentries.org'
 # - another-learner.md
 
 # Order of episodes in your lesson
-episodes: 
+episodes:
 - 01-introduction.md
 - 02-working-with-openrefine.md
 - 03-filter-sort.md
@@ -68,13 +68,13 @@ episodes:
 - 07-resources.md
 
 # Information for Learners
-learners: 
+learners:
 
 # Information for Instructors
-instructors: 
+instructors:
 
 # Learner Profiles
-profiles: 
+profiles:
 
 # Customisation ---------------------------------------------
 #
@@ -82,6 +82,6 @@ profiles:
 # sandpaper and varnish versions) should live
 
 
-url: 'https://datacarpentry.github.io/openrefine-socialsci'
+url: 'https://datacarpentry.org/openrefine-socialsci'
 analytics: carpentries
 lang: en

--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ title: 'OpenRefine for Social Science Data'
 created: '2017-05-25'
 
 # Comma-separated list of keywords for the lesson
-keywords: 'software, data, lesson, The Carpentries'
+keywords: 'OpenRefine, data cleaning, data, lesson, The Carpentries'
 
 # Life cycle stage of the lesson
 # possible values: pre-alpha, alpha, beta, stable


### PR DESCRIPTION
This URL is used to generate the JSON-LD metadata, as mentioned in https://github.com/carpentries/sandpaper-docs/discussions/137. The editor removed trailing whitespace too.

After merging, the URLs below should point to the proper domain:

```html
<script type="application/ld+json">
    {
  "@context": "https://schema.org",
  "@type": "TrainingMaterial",
  "@id": "https://datacarpentry.github.io/openrefine-socialsci/01-introduction.html",
  "dct:conformsTo": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE",
  "description": "A Carpentries Lesson teaching foundational data and coding skills to researchers worldwide",
  "keywords": "software, data, lesson, The Carpentries",
  "name": "Introduction",
  "creativeWorkStatus": "active",
  "url": "https://datacarpentry.github.io/openrefine-socialsci/01-introduction.html",
  "identifier": "https://datacarpentry.github.io/openrefine-socialsci/01-introduction.html",
  "dateCreated": "2017-05-25",
  "dateModified": "2023-05-31",
  "datePublished": "2023-06-13"
}
</script>
```

I will update the keywords too. Other suggestions to improve and enrich the metadata depend on the template and may be tracked in https://github.com/carpentries/sandpaper/issues/481.