### PR TITLE
Add lesson learning objectives, move Getting Help

### DIFF
--- a/episodes/01-introduction.md
+++ b/episodes/01-introduction.md
@@ -9,7 +9,6 @@ exercises: 0
 - Describe OpenRefine’s uses and applications.
 - Differentiate data cleaning from data organization.
 - Experiment with OpenRefine’s user interface.
-- Locate helpful resources to learn more about OpenRefine.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/01-introduction.md
+++ b/episodes/01-introduction.md
@@ -97,18 +97,7 @@ If after installation and running OpenRefine, it does not automatically open
 for you, point your browser at [http://127.0.0.1:3333/](https://127.0.0.1:3333/)
 or [http://localhost:3333](https://localhost:3333) to launch the program.
 
-## Getting help for OpenRefine
 
-You can find out a lot more about OpenRefine at [openrefine.org](https://openrefine.org)
-and check out some great introductory videos.
-
-These videos and others on OpenRefine can also be found on YouTube by searching under
-'OpenRefine'.  There is an [official forum](https://forum.openrefine.org/) that
-can answer a lot of beginner questions and problems. Information can also be found on
-[StackOverflow](https://stackoverflow.com/questions/tagged/openrefine) where
-you can find a lot of help. As with other programs of this type, OpenRefine
-libraries are available too, where you can find a script you need and copy it
-into your OpenRefine instance to run it on your dataset.
 
 
 

--- a/episodes/07-resources.md
+++ b/episodes/07-resources.md
@@ -17,6 +17,19 @@ exercises: 5
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+## Getting help for OpenRefine
+
+You can find out a lot more about OpenRefine at [openrefine.org](https://openrefine.org)
+and check out some great introductory videos.
+
+These videos and others on OpenRefine can also be found on YouTube by searching under
+'OpenRefine'.  There is an [official forum](https://forum.openrefine.org/) that
+can answer a lot of beginner questions and problems. Information can also be found on
+[StackOverflow](https://stackoverflow.com/questions/tagged/openrefine) where
+you can find a lot of help. As with other programs of this type, OpenRefine
+libraries are available too, where you can find a script you need and copy it
+into your OpenRefine instance to run it on your dataset.
+
 ## Using online resources to get help with OpenRefine
 
 OpenRefine is more than a simple data cleaning tool. People are using it for

--- a/episodes/07-resources.md
+++ b/episodes/07-resources.md
@@ -7,7 +7,7 @@ exercises: 5
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Understand that there are many online resources available for more information on OpenRefine.
-- Identify other resources about OpenRefine.
+- Locate helpful resources to learn more about OpenRefine.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/index.md
+++ b/index.md
@@ -11,6 +11,16 @@ OpenRefine (formerly Google Refine) is a powerful free and open source tool for
 working with messy data: cleaning it and transforming it from one format into
 another.
 
+## Learning objectives
+
+By the end of this lesson, you will be able to:
+
+- create, export and import a project in OpenRefine
+- view and work on subsets of rows using facets and text filters
+- reduce variations in data through clustering, bulk editing and transformations
+- undo and redo actions and export the history of actions
+- save cleaned data in a widely supported file format
+
 This lesson will teach you to use OpenRefine to effectively clean and format
 data and automatically track any changes that you make. Many people comment
 that this tool saves them literally months of work trying to make these

--- a/index.md
+++ b/index.md
@@ -26,6 +26,8 @@ data and automatically track any changes that you make. Many people comment
 that this tool saves them literally months of work trying to make these
 edits by hand.
 
+Importantly, this lesson does not cover all of OpenRefine's functionalities.
+It also does not correct all errors in the provided dataset.
 
 ## Getting Started
 


### PR DESCRIPTION
This fixes #38. It also relates to #122.

Overview:

- add lesson learning objectives, not to the introduction (#38) but Summary and Setup (as in [Lesson Development Training](https://carpentries.github.io/lesson-development-training/index.html))
- move "Getting Help" from Introduction to Other Resources (almost #122)

I don't think I wrote new learning objectives, but perhaps the @datacarpentry/curriculum-advisors-social-science would like to check?